### PR TITLE
fix: can't get appConfig in appConfig

### DIFF
--- a/lib/loader/egg_loader.js
+++ b/lib/loader/egg_loader.js
@@ -7,8 +7,7 @@ const isFunction = require('is-type-of').function;
 const debug = require('debug')('egg-core');
 const FileLoader = require('./file_loader');
 const ContextLoader = require('./context_loader');
-const loadFile = require('../utils').loadFile;
-const getHomedir = require('../utils').getHomedir;
+const utils = require('../utils');
 const EggCore = require('../egg');
 
 class EggLoader {
@@ -57,7 +56,7 @@ class EggLoader {
       name: this.getAppname(),
       baseDir: this.options.baseDir,
       env: this.serverEnv,
-      HOME: getHomedir(),
+      HOME: utils.getHomedir(),
       pkg: this.pkg,
     };
   }
@@ -190,7 +189,7 @@ class EggLoader {
       return null;
     }
 
-    const ret = loadFile(filepath);
+    const ret = utils.loadFile(filepath);
     // function(arg1, args, ...) {}
     let inject = Array.prototype.slice.call(arguments, 1);
     if (inject.length === 0) inject = [ this.app ];

--- a/lib/loader/file_loader.js
+++ b/lib/loader/file_loader.js
@@ -6,7 +6,7 @@ const debug = require('debug')('egg-core:loader');
 const path = require('path');
 const globby = require('globby');
 const is = require('is-type-of');
-const loadFile = require('../utils').loadFile;
+const utils = require('../utils');
 const FULLPATH = Symbol('EGG_LOADER_ITEM_FULLPATH');
 const EXPORTS = Symbol('EGG_LOADER_ITEM_EXPORTS');
 
@@ -115,7 +115,7 @@ function getProperties(filepath, lowercaseFirst) {
 // Get exports from filepath
 // If exports is null/undefined, it will be ignored
 function getExports(fullpath, initializer, isCall, inject) {
-  let exports = loadFile(fullpath);
+  let exports = utils.loadFile(fullpath);
 
   // process exports as you like
   if (initializer) {

--- a/lib/loader/mixin/config.js
+++ b/lib/loader/mixin/config.js
@@ -36,7 +36,8 @@ module.exports = {
     //             app config.{env}
     for (const filename of names) {
       for (const unit of this.getLoadUnits()) {
-        const config = this._loadConfig(unit.path, filename, appConfig, unit.type);
+        const isApp = unit.type === 'app';
+        const config = this._loadConfig(unit.path, filename, isApp ? undefined : appConfig, unit.type);
 
         if (!config) {
           continue;

--- a/test/fixtures/preload-app-config/config/config.js
+++ b/test/fixtures/preload-app-config/config/config.js
@@ -1,12 +1,13 @@
 'use strict';
 
-module.exports = function(antx) {
+module.exports = function(antx, appConfig) {
   return {
     app: {
       sub: {
         val: 1
       },
       val: 2,
-    }
+    },
+    appInApp: appConfig != null,
   };
 };

--- a/test/loader/mixin/load_config.test.js
+++ b/test/loader/mixin/load_config.test.js
@@ -112,5 +112,6 @@ describe('test/loader/mixin/load_config.test.js', function() {
     loader.config.plugin.val.should.eql(2);
     loader.config.plugin.val.should.eql(2);
     loader.config.plugin.sub.should.not.equal(loader.config.app.sub);
+    loader.config.appInApp.should.false();
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

loadConfig

##### Description of change
<!-- Provide a description of the change below this comment. -->

app config 里不能取 app config