### PR TITLE
fix: always get the executor's homedir

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const interopRequire = require('interop-require');
+const homedir = require('node-homedir');
 
 module.exports = {
 
@@ -25,7 +26,7 @@ module.exports = {
   },
 
   getHomedir() {
-    return process.env.HOME || '/home/admin';
+    return homedir() || '/home/admin';
   },
 
   methods: [ 'head', 'options', 'get', 'put', 'patch', 'post', 'delete' ],

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2,7 +2,7 @@
 
 const interopRequire = require('interop-require');
 
-module.exports = exports = {
+module.exports = {
 
   loadFile(filepath) {
     let exports;

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "is-type-of": "^1.0.0",
     "koa": "^1.2.1",
     "koa-router": "^5.4.0",
+    "node-homedir": "^0.0.1",
     "ready-callback": "^1.0.0",
     "utility": "^1.8.0"
   }

--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const mm = require('mm');
+const os = require('os');
 const utils = require('../../lib/utils');
+const should = require('should');
 
 describe('test/utils/index.test.js', () => {
 
@@ -9,12 +11,21 @@ describe('test/utils/index.test.js', () => {
 
   describe('utils.getHomedir()', () => {
     it('should return process.env.HOME', () => {
+      if (os.userInfo && os.userInfo().homedir) {
+        const userInfo = os.userInfo();
+        delete userInfo.homedir;
+        mm(os, 'userInfo', () => userInfo);
+      }
       utils.getHomedir().should.equal(process.env.HOME);
     });
 
     it('should return /home/admin when process.env.HOME is not exist', () => {
       mm(process.env, 'HOME', '');
-      utils.getHomedir().should.equal('/home/admin');
+      if (os.userInfo && os.userInfo().homedir) {
+        should.ok(utils.getHomedir().indexOf(process.env.USER) > -1);
+      } else {
+        utils.getHomedir().should.equal('/home/admin');
+      }
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] `npm test` passes
- [ x ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ x ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

总是获取当前执行者的用户目录，保证不会权限错乱。当前执行者用户的判断由启动脚本来判断保证。
错乱的场景：`sudo -u admin node app.js`，此时`id -nu`返回的是`admin`。但是`process.env.HOME`并不是admin