### PR TITLE
feat: warning when missing EGG_SERVER_ENV at production

### DIFF
--- a/lib/loader/egg_loader.js
+++ b/lib/loader/egg_loader.js
@@ -95,6 +95,7 @@ class EggLoader {
       if (process.env.NODE_ENV === 'test') {
         serverEnv = 'unittest';
       } else if (process.env.NODE_ENV === 'production') {
+        console.warn('NODE_ENV is production but EGG_SERVER_ENV is empty, forgot `EGG_SERVER_ENV=prod`? see https://github.com/eggjs/egg-core/blob/master/lib/loader/egg_loader.js#L82 for more detail.');
         serverEnv = 'default';
       } else {
         serverEnv = 'local';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

开源版很多情况下, 都是直接使用 egg 而不是上层框架.
很多人会直接使用 NODE_ENV 而不知道 EGG_SERVER_ENV
因此给个 warning 指引, 后面文档完善后可以修改对应的 url.
