### PR TITLE
fix: router.url can't parse multi params right

### DIFF
--- a/lib/utils/router.js
+++ b/lib/utils/router.js
@@ -176,7 +176,7 @@ class Router extends KoaRouter {
       const queries = [];
       if (typeof args === 'object' && args !== null) {
         const replacedParams = [];
-        url = url.replace(/:([a-zA-Z_]\w*)/, function($0, key) {
+        url = url.replace(/:([a-zA-Z_]\w*)/g, function($0, key) {
           if (utility.has(args, key)) {
             const values = args[key];
             replacedParams.push(key);

--- a/test/fixtures/router-app/app/router.js
+++ b/test/fixtures/router-app/app/router.js
@@ -5,5 +5,6 @@ module.exports = function (app) {
   app.resources('members', '/members', app.controller.members);
   app.resources('/comments', app.controller.comments);
   app.get('comment_index', '/comments/:id?filter=', app.controller.comments.index);
+  app.get('params', '/params/:a/:b', app.controller.locals.router);
   app.register('/comments', [ 'post' ] , app.controller.comments.new);
 };

--- a/test/utils/router.test.js
+++ b/test/utils/router.test.js
@@ -139,6 +139,7 @@ describe('test/utils/router.test.js', () => {
       app.router.url('new_post').should.equal('/posts/new');
       app.router.url('new_member').should.equal('/members/new');
       app.router.url('edit_post', { id: 1 }).should.equal('/posts/1/edit');
+      app.router.url('params', { a: 1, b: 2 }).should.eql('/params/1/2');
       // no match params
       app.router.url('edit_post', {}).should.equal('/posts/:id/edit');
       app.router.url('noname').should.equal('');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
`router.url` 方法替换`/:XX`时并非全局替换，所以在处理多个`/:XX`时会替换失败。给正则添加 global 标识以修复该问题。
