### PR TITLE
refactor: seperate router api from app

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -9,12 +9,14 @@ const is = require('is-type-of');
 const co = require('co');
 const BaseContextClass = require('./utils/base_context_class');
 const utils = require('./utils');
+const Router = require('./utils/router');
 
 
 const DEPRECATE = Symbol('EggCore#deprecate');
 const CLOSESET = Symbol('EggCore#closeSet');
 const ISCLOSE = Symbol('EggCore#isClose');
 const CLOSE_PROMISE = Symbol('EggCore#closePromise');
+const ROUTER = Symbol('EggCore#router');
 
 class EggCore extends KoaApplication {
 
@@ -265,7 +267,44 @@ class EggCore extends KoaApplication {
 
     this.ready(() => debug('egg emit ready, application started'));
   }
+
+  /**
+   * get router
+   * @member {Router} EggCore#router
+   */
+  get router() {
+    if (this[ROUTER]) {
+      return this[ROUTER];
+    }
+    const router = this[ROUTER] = new Router({ sensitive: true }, this);
+    // register router middleware
+    this.use(router.middleware());
+    return router;
+  }
+
+  /**
+   * Alias to {@link Router#url}
+   * @param {String} name - Router name
+   * @param {Object} params - more parameters
+   * @return {String} url
+   */
+  url(name, params) {
+    return this.router.url(name, params);
+  }
+
+  del(...args) {
+    this.router.delete(...args);
+    return this;
+  }
 }
+
+// delegate all router method to application
+utils.methods.concat([ 'all', 'resources', 'register', 'redirect' ]).forEach(method => {
+  EggCore.prototype[method] = function(...args) {
+    this.router[method](...args);
+    return this;
+  };
+});
 
 module.exports = EggCore;
 

--- a/lib/loader/mixin/router.js
+++ b/lib/loader/mixin/router.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const Router = require('../../utils/router');
 
 module.exports = {
 
@@ -12,12 +11,6 @@ module.exports = {
    * @since 1.0.0
    */
   loadRouter() {
-    const app = this.app;
-    const router = new Router({ sensitive: true }, app);
-
-    // 注册 Router 的 Middleware
-    app.use(router.middleware());
-
     // 加载 router.js
     this.loadFile(path.join(this.options.baseDir, 'app/router.js'));
   },

--- a/lib/utils/router.js
+++ b/lib/utils/router.js
@@ -47,8 +47,6 @@ const REST_MAP = {
   },
 };
 
-const slice = Array.prototype.slice;
-
 class Router extends KoaRouter {
 
   /**
@@ -58,41 +56,35 @@ class Router extends KoaRouter {
    */
   constructor(opts, app) {
     super(opts);
+    this.app = app;
     // patch koa-router@5.x
-    this.patchRouter(app);
+    this.patchRouterMethod();
   }
 
-  patchRouter(app) {
-    const router = this;
-    router.app = app;
-    app.url = router.url.bind(router);
-    app.router = router;
-
+  patchRouterMethod() {
     // patch router methods to support async function middleware and string controller
-    methods.concat([ 'all', 'del', 'resources' ]).forEach(method => {
-      const orignalMethod = router[method].bind(router);
-      router[method] = function(...args) {
+    methods.concat([ 'all' ]).forEach(method => {
+      this[method] = (...args) => {
         const splited = splitedRouterParams(args);
-        args = splited.prefix.concat(convertMiddlewares(splited.middlewares, app));
-        return orignalMethod(...args);
+        args = splited.prefix.concat(convertMiddlewares(splited.middlewares, this.app));
+        return super[method](...args);
       };
     });
+  }
 
+  /**
+   * Create and register a route.
+   * @param {String} path - url path
+   * @param {Array} methods - Array of HTTP verbs
+   * @param {Array} middlewares -
+   * @param {Object} opts -
+   * @return {Route} this
+   */
+  register(path, methods, middlewares, opts) {
     // patch register to support async function middleware and string controller
-    const register = router.register.bind(router);
-    router.register = function(path, methods, middlewares, opts) {
-      middlewares = Array.isArray(middlewares) ? middlewares : [ middlewares ];
-      middlewares = convertMiddlewares(middlewares, app);
-      return register(path, methods, middlewares, opts);
-    };
-
-    // delegate
-    methods.concat([ 'all', 'del', 'resources', 'register', 'redirect' ]).forEach(method => {
-      app[method] = function(...args) {
-        router[method](...args);
-        return this;
-      };
-    });
+    middlewares = Array.isArray(middlewares) ? middlewares : [ middlewares ];
+    middlewares = convertMiddlewares(middlewares, this.app);
+    return super.register(path, methods, middlewares, opts);
   }
 
   /**
@@ -136,16 +128,21 @@ class Router extends KoaRouter {
    * app.router.url('edit_post', { id: 1 })
    * => /posts/1/edit
    * ```
-   * @return {Route} return route object.
+   * @return {Router} return route object.
    */
-  resources(name, prefix, middleware) {
-    const route = this;
-    if (typeof prefix === 'string') {
-      middleware = slice.call(arguments, 2);
+  resources(...args) {
+    const splited = splitedRouterParams(args);
+    const middleware = convertMiddlewares(splited.middlewares, this.app);
+
+    let name = '';
+    let prefix = '';
+    if (splited.prefix.length === 2) {
+      // router.get('users', '/users')
+      name = splited.prefix[0];
+      prefix = splited.prefix[1];
     } else {
-      middleware = slice.call(arguments, 1);
-      prefix = name;
-      name = '';
+      // router.get('/users')
+      prefix = splited.prefix[0];
     }
 
     // last argument is Controller object
@@ -167,10 +164,10 @@ class Router extends KoaRouter {
       }
       prefix = prefix.replace(/\/$/, '');
       const path = opts.suffix ? `${prefix}/${opts.suffix}` : prefix;
-      route.register.call(this, path, [ opts.method ], middleware.concat(action), { name: formatedName });
+      this.register(path, [ opts.method ], middleware.concat(action), { name: formatedName });
     }
 
-    return route;
+    return this;
   }
 
   /**

--- a/test/fixtures/router-app/app/controller/members.js
+++ b/test/fixtures/router-app/app/controller/members.js
@@ -13,3 +13,7 @@ exports.new = function* () {
 exports.show = function* () {
   this.body = 'show - ' + this.params.id;
 };
+
+exports.delete = function* () {
+  this.body = `delete - ${this.params.id}`;
+};

--- a/test/fixtures/router-app/app/router.js
+++ b/test/fixtures/router-app/app/router.js
@@ -6,6 +6,8 @@ module.exports = function (app) {
   app
     .get('/locals/router', app.controller.locals.router)
     .get('/members/index', 'members.index')
+    .delete('/members/delete/:id', 'members.delete')
+    .del('/members/del/:id', 'members.delete')
     .resources('posts', '/posts', 'posts')
     .resources('members', '/members', app.controller.members)
     .resources('/comments', app.controller.comments)

--- a/test/utils/router.test.js
+++ b/test/utils/router.test.js
@@ -121,6 +121,20 @@ describe('test/utils/router.test.js', () => {
           .get('/POSTS')
           .expect(404);
       });
+
+      it('should GET /members/delete/:id', () => {
+        return request(app.callback())
+          .delete('/members/delete/1')
+          .expect(200)
+          .expect('delete - 1');
+      });
+
+      it('should GET /members/del/:id', () => {
+        return request(app.callback())
+          .del('/members/del/1')
+          .expect(200)
+          .expect('delete - 1');
+      });
     });
 
     describe('no name', function() {
@@ -142,6 +156,8 @@ describe('test/utils/router.test.js', () => {
 
   describe('router.url', () => {
     it('should work', () => {
+      assert(app.url('posts') === '/posts');
+
       assert(app.router.url('posts') === '/posts');
       assert(app.router.url('members') === '/members');
       assert(app.router.url('post', { id: 1 }) === '/posts/1');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

- move app API to egg.js from router.js
- use super instead of monkey patch

