### PR TITLE
feat: load plugin.default.js rather than plugin.js

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -56,11 +56,11 @@ module.exports = {
    */
   loadPlugin() {
     // loader plugins from application
-    const appPlugins = this.readPluginConfigs(path.join(this.options.baseDir, 'config/plugin.js'));
+    const appPlugins = this.readPluginConfigs(path.join(this.options.baseDir, 'config/plugin.default.js'));
     debug('Loaded app plugins: %j', Object.keys(appPlugins));
 
     // loader plugins from framework
-    const eggPluginConfigPaths = this.eggPaths.map(eggPath => path.join(eggPath, 'config/plugin.js'));
+    const eggPluginConfigPaths = this.eggPaths.map(eggPath => path.join(eggPath, 'config/plugin.default.js'));
     const eggPlugins = this.readPluginConfigs(eggPluginConfigPaths);
     debug('Loaded egg plugins: %j', Object.keys(eggPlugins));
 
@@ -148,15 +148,20 @@ module.exports = {
       configPaths = [ configPaths ];
     }
 
-    // read plugin.js and plugins.${env}.js
+    // read plugin.default.js and plugins.${env}.js
     // note: can't use for-of
     for (let i = 0, l = configPaths.length; i < l; i++) {
       const configPath = configPaths[i];
-      configPaths.push(configPath.replace(/plugin.js$/, `plugin.${this.serverEnv}.js`));
+      configPaths.push(configPath.replace(/plugin\.default\.js$/, `plugin.${this.serverEnv}.js`));
     }
 
     const plugins = {};
-    for (const configPath of configPaths) {
+    for (let configPath of configPaths) {
+      // let plugin.js compatible
+      if (configPath.endsWith('plugin.default.js') && !fs.existsSync(configPath)) {
+        configPath = configPath.replace(/plugin\.default\.js$/, 'plugin.js');
+      }
+
       if (!fs.existsSync(configPath)) {
         continue;
       }

--- a/test/fixtures/load-plugin-default/config/plugin.default.js
+++ b/test/fixtures/load-plugin-default/config/plugin.default.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const path = require('path');
+
+exports.c = {
+  enable: true,
+  path: path.join(__dirname, '../plugins/c'),
+}

--- a/test/fixtures/load-plugin-default/config/plugin.js
+++ b/test/fixtures/load-plugin-default/config/plugin.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const path = require('path');
+
+exports.a = {
+  enable: true,
+  path: path.join(__dirname, '../plugins/a'),
+}

--- a/test/fixtures/load-plugin-default/config/plugin.unittest.js
+++ b/test/fixtures/load-plugin-default/config/plugin.unittest.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const path = require('path');
+
+exports.b = {
+  enable: true,
+  path: path.join(__dirname, '../plugins/b'),
+}

--- a/test/fixtures/load-plugin-default/package.json
+++ b/test/fixtures/load-plugin-default/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "load-plugin-default"
+}

--- a/test/fixtures/load-plugin-default/plugins/a/package.json
+++ b/test/fixtures/load-plugin-default/plugins/a/package.json
@@ -1,0 +1,5 @@
+{
+  "eggPlugin": {
+    "name": "a"
+  }
+}

--- a/test/fixtures/load-plugin-default/plugins/b/package.json
+++ b/test/fixtures/load-plugin-default/plugins/b/package.json
@@ -1,0 +1,5 @@
+{
+  "eggPlugin": {
+    "name": "b"
+  }
+}

--- a/test/fixtures/load-plugin-default/plugins/c/package.json
+++ b/test/fixtures/load-plugin-default/plugins/c/package.json
@@ -1,0 +1,5 @@
+{
+  "eggPlugin": {
+    "name": "c"
+  }
+}

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -417,6 +417,16 @@ describe('test/load_plugin.test.js', function() {
     assert(loader.allPlugins.c.enable === true);
   });
 
+  it('should not load plugin.js when plugin.default.js exist', function() {
+    mm(process.env, 'EGG_SERVER_ENV', 'unittest');
+    app = utils.createApp('load-plugin-default');
+    const loader = app.loader;
+    loader.loadPlugin();
+    assert(!loader.allPlugins.a);
+    assert(loader.allPlugins.b.enable === true);
+    assert(loader.allPlugins.c.enable === true);
+  });
+
   it('should warn when redefine plugin', () => {
     app = utils.createApp('load-plugin-config-override');
     mm(app.console, 'warn', function(msg, name, targetPlugin, from) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
- when `plugin.default.js` exist, load it, rather than `plugin.js`, just like `config loader`
- close https://github.com/eggjs/egg/issues/389