### PR TITLE
fix: ensure deprecate display the right call stack

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -157,7 +157,7 @@ class EggCore extends KoaApplication {
    */
   get deprecate() {
     const caller = utils.getCalleeFromStack();
-    if (!this[DEPRECATE].get(caller)) {
+    if (!this[DEPRECATE].has(caller)) {
       const deprecate = require('depd')('egg');
       // dynamic set _file to caller
       deprecate._file = caller;

--- a/lib/egg.js
+++ b/lib/egg.js
@@ -58,6 +58,8 @@ class EggCore extends KoaApplication {
 
     // register a close set
     this[CLOSESET] = new Set();
+    // cache deprecate object by file
+    this[DEPRECATE] = new Map();
 
     /**
      * @member {BaseContextClass} EggCore#BaseContextClass
@@ -154,11 +156,14 @@ class EggCore extends KoaApplication {
    * @since 1.0.0
    */
   get deprecate() {
-    if (!this[DEPRECATE]) {
-      // require depd when get, `process.env.NO_DEPRECATION = '*'` should be use when run test everytime
-      this[DEPRECATE] = require('depd')('egg');
+    const caller = utils.getCalleeFromStack();
+    if (!this[DEPRECATE].get(caller)) {
+      const deprecate = require('depd')('egg');
+      // dynamic set _file to caller
+      deprecate._file = caller;
+      this[DEPRECATE].set(caller, deprecate);
     }
-    return this[DEPRECATE];
+    return this[DEPRECATE].get(caller);
   }
 
   /**
@@ -200,7 +205,7 @@ class EggCore extends KoaApplication {
     }
 
     // get filename from stack
-    const name = getCalleeFromStack();
+    const name = utils.getCalleeFromStack(true);
     const done = this.readyCallback(name);
 
     // ensure scope excutes after load completed
@@ -336,11 +341,3 @@ utils.methods.concat([ 'all', 'resources', 'register', 'redirect' ]).forEach(met
 });
 
 module.exports = EggCore;
-
-function getCalleeFromStack() {
-  const _ = new Error();
-  /* istanbul ignore next */
-  const line = _.stack.split('\n')[3] || '';
-  const parsed = line.match(/\((.*?)\)/);
-  return parsed && parsed[1];
-}

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -74,6 +74,7 @@ module.exports = {
     Error.stackTraceLimit = limit;
 
     const callSite = obj.stack[2];
+    /* istanbul ignore next */
     if (!callSite) return '<anonymous>';
     const fileName = callSite.getFileName();
     if (!withLine || !fileName) return fileName || '<anonymous>';
@@ -84,6 +85,7 @@ module.exports = {
 
 /**
  * Capture call site stack from v8.
+ * https://github.com/v8/v8/wiki/Stack-Trace-API
  */
 
 function prepareObjectStackTrace(obj, stack) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -58,4 +58,34 @@ module.exports = {
       yield module.exports.callFn(fn, [ this, () => co(next) ]);
     };
   },
+
+  getCalleeFromStack(withLine) {
+    const limit = Error.stackTraceLimit;
+    const prep = Error.prepareStackTrace;
+
+    Error.prepareStackTrace = prepareObjectStackTrace;
+    Error.stackTraceLimit = 3;
+
+    // capture the stack
+    const obj = {};
+    Error.captureStackTrace(obj);
+
+    Error.prepareStackTrace = prep;
+    Error.stackTraceLimit = limit;
+
+    const callSite = obj.stack[2];
+    if (!callSite) return '<anonymous>';
+    const fileName = callSite.getFileName();
+    if (!withLine || !fileName) return fileName || '<anonymous>';
+    return `${fileName}:${callSite.getLineNumber()}:${callSite.getColumnNumber()}`;
+  },
 };
+
+
+/**
+ * Capture call site stack from v8.
+ */
+
+function prepareObjectStackTrace(obj, stack) {
+  return stack;
+}

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -69,11 +69,11 @@ module.exports = {
     // capture the stack
     const obj = {};
     Error.captureStackTrace(obj);
+    const callSite = obj.stack[2];
 
     Error.prepareStackTrace = prep;
     Error.stackTraceLimit = limit;
 
-    const callSite = obj.stack[2];
     /* istanbul ignore next */
     if (!callSite) return '<anonymous>';
     const fileName = callSite.getFileName();

--- a/test/egg.test.js
+++ b/test/egg.test.js
@@ -107,12 +107,12 @@ describe('test/egg.test.js', () => {
       let deprecate = app.deprecate;
       assert(deprecate._namespace === 'egg');
       assert(deprecate === app.deprecate);
-      assert(deprecate._file.endsWith('test/egg.test.js'));
+      assert(deprecate._file.match(/test(\/|\\)egg\.test\.js/));
 
       deprecate = app.env;
       assert(deprecate._namespace === 'egg');
       assert(deprecate !== app.deprecate);
-      assert(deprecate._file.endsWith('app/extend/application.js'));
+      assert(deprecate._file.match(/extend(\/|\\)application\.js/));
     });
   });
 

--- a/test/egg.test.js
+++ b/test/egg.test.js
@@ -102,10 +102,17 @@ describe('test/egg.test.js', () => {
     afterEach(() => app && app.close());
 
     it('should deprecate with namespace egg', () => {
-      app = utils.createApp('plugin');
-      const deprecate = app.deprecate;
+      app = utils.createApp('deprecate');
+      app.loader.loadAll();
+      let deprecate = app.deprecate;
       assert(deprecate._namespace === 'egg');
       assert(deprecate === app.deprecate);
+      assert(deprecate._file.endsWith('test/egg.test.js'));
+
+      deprecate = app.env;
+      assert(deprecate._namespace === 'egg');
+      assert(deprecate !== app.deprecate);
+      assert(deprecate._file.endsWith('app/extend/application.js'));
     });
   });
 

--- a/test/fixtures/deprecate/app/extend/application.js
+++ b/test/fixtures/deprecate/app/extend/application.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  get env() {
+    this.deprecate('please use app.config.env instead');
+    return this.deprecate;
+  },
+};

--- a/test/fixtures/deprecate/package.json
+++ b/test/fixtures/deprecate/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "deprecate"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

![image](https://cloud.githubusercontent.com/assets/985607/24849898/66819b8e-1e00-11e7-9aba-7634585d741d.png)

增加的损耗：每次调用 deprecate 都需要捕获一次堆栈。