### PR TITLE
feat: always load extend/xx.unittest.js when run test

### DIFF
--- a/lib/loader/mixin/extend.js
+++ b/lib/loader/mixin/extend.js
@@ -77,13 +77,15 @@ module.exports = {
    * @since 1.0.0
    */
   loadExtend(name, proto) {
-    // 获取需要加载的文件
+    // All extend files
     const filepaths = this.getLoadUnits().map(unit => path.join(unit.path, 'app/extend', name));
+    // if use mm.env and serverEnv is not unittest
+    const isAddUnittest = 'EGG_MOCK_SERVER_ENV' in process.env && this.serverEnv !== 'unittest';
     for (let i = 0, l = filepaths.length; i < l; i++) {
       const filepath = filepaths[i];
       filepaths.push(filepath + `.${this.serverEnv}`);
+      if (isAddUnittest) filepaths.push(filepath + '.unittest');
     }
-
 
     const mergeRecord = new Map();
     for (const filepath of filepaths) {

--- a/test/fixtures/load-plugin-unittest/app/extend/application.local.js
+++ b/test/fixtures/load-plugin-unittest/app/extend/application.local.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  local: true,
+};

--- a/test/fixtures/load-plugin-unittest/app/extend/application.unittest.js
+++ b/test/fixtures/load-plugin-unittest/app/extend/application.unittest.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  unittest: true,
+};

--- a/test/fixtures/load-plugin-unittest/package.json
+++ b/test/fixtures/load-plugin-unittest/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "load-plugin-unittest"
+}

--- a/test/loader/mixin/load_extend.test.js
+++ b/test/loader/mixin/load_extend.test.js
@@ -19,6 +19,7 @@ describe('test/loader/mixin/load_extend.test.js', () => {
     app.loader.loadRouter();
   });
   after(() => app.close());
+  afterEach(mm.restore);
 
   it('should load app.context app.request app.response', () => {
     assert(app.context.appContext);
@@ -110,4 +111,26 @@ describe('test/loader/mixin/load_extend.test.js', () => {
     assert(app.b === 'b1');
   });
 
+  describe('load unittest extend', () => {
+    let app;
+    after(() => app.close());
+
+    it('should load unittext.js when unittest', function* () {
+      app = utils.createApp('load-plugin-unittest');
+      app.loader.loadPlugin();
+      app.loader.loadApplicationExtend();
+      assert(app.unittest === true);
+      assert(app.local !== true);
+    });
+
+    it('should load unittext.js when mm.env(default)', function* () {
+      mm(process.env, 'EGG_SERVER_ENV', 'local');
+      mm(process.env, 'EGG_MOCK_SERVER_ENV', 'local');
+      app = utils.createApp('load-plugin-unittest');
+      app.loader.loadPlugin();
+      app.loader.loadApplicationExtend();
+      assert(app.unittest === true);
+      assert(app.local === true);
+    });
+  });
 });

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -469,4 +469,5 @@ describe('test/load_plugin.test.js', function() {
     app.loader.loadPlugin();
     assert(warn.callCount === 0);
   });
+
 });


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

loadExtend

##### Description of change
<!-- Provide a description of the change below this comment. -->

When use mm.env, EGG_SERVER_ENV will be changed,
but xx.unittest.js will also be loaded

Closes https://github.com/eggjs/egg/issues/404
