### PR TITLE
fix: should support module.exports = function*(ctx) {} as a controller

### DIFF
--- a/lib/loader/mixin/controller.js
+++ b/lib/loader/mixin/controller.js
@@ -36,6 +36,9 @@ module.exports = {
         if (is.object(obj)) {
           return wrapObject(obj, opt.path);
         }
+        if (is.generatorFunction(obj)) {
+          return wrapObject({ 'module.exports': obj }, opt.path)['module.exports'];
+        }
         return obj;
       },
     }, opt);

--- a/test/fixtures/controller-app/app/controller/generator_function_ctx.js
+++ b/test/fixtures/controller-app/app/controller/generator_function_ctx.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function* (ctx) {
+  ctx.body = 'done';
+};

--- a/test/fixtures/controller-app/app/controller/number.js
+++ b/test/fixtures/controller-app/app/controller/number.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 123;

--- a/test/fixtures/controller-app/app/router.js
+++ b/test/fixtures/controller-app/app/router.js
@@ -2,6 +2,7 @@
 
 module.exports = app => {
   app.get('/generator-function', 'generatorFunction');
+  app.get('/generator-function-ctx', 'generatorFunctionCtx');
 
   app.get('/object-function', 'object.callFunction');
   app.get('/object-generator-function', 'object.callGeneratorFunction');

--- a/test/loader/mixin/load_controller.test.js
+++ b/test/loader/mixin/load_controller.test.js
@@ -229,4 +229,10 @@ describe('test/loader/mixin/load_controller.test.js', () => {
       });
     });
   });
+
+  describe('not controller', () => {
+    it('should load a number', () => {
+      assert(app.controller.number === 123);
+    });
+  });
 });

--- a/test/loader/mixin/load_controller.test.js
+++ b/test/loader/mixin/load_controller.test.js
@@ -38,6 +38,15 @@ describe('test/loader/mixin/load_controller.test.js', () => {
         .expect(200)
         .expect('done');
     });
+
+    it('should first argument is ctx', () => {
+      assert(app.controller.generatorFunction);
+
+      return request(app.callback())
+        .get('/generator-function-ctx')
+        .expect(200)
+        .expect('done');
+    });
   });
 
   describe('when controller is object', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

closes https://github.com/eggjs/egg/issues/785