### PR TITLE
feat: app timeout support config by env

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -42,7 +42,11 @@ class EggCore extends KoaApplication {
 
     super();
 
-    this[EGG_READY_TIMEOUT_ENV] = Number.parseInt(process.env.EGG_READY_TIMEOUT_ENV || 10000);
+    // get app timeout from env or use default timeout 10 second
+    const eggReadyTimeoutEnv = process.env.EGG_READY_TIMEOUT_ENV;
+    this[EGG_READY_TIMEOUT_ENV] = Number.parseInt(eggReadyTimeoutEnv || 10000);
+
+    assert(Number.isInteger(this[EGG_READY_TIMEOUT_ENV]), `process.env.EGG_READY_TIMEOUT_ENV ${eggReadyTimeoutEnv} should be able to parseInt.`);
 
     /**
      * @member {Object} EggCore#_options

--- a/lib/egg.js
+++ b/lib/egg.js
@@ -19,6 +19,7 @@ const CLOSE_PROMISE = Symbol('EggCore#closePromise');
 const ROUTER = Symbol('EggCore#router');
 const EGG_LOADER = Symbol.for('egg#loader');
 const INIT_READY = Symbol('EggCore#initReady');
+const EGG_READY_TIMEOUT_ENV = Symbol('EggCore#eggReadyTimeoutEnv');
 
 class EggCore extends KoaApplication {
 
@@ -40,6 +41,8 @@ class EggCore extends KoaApplication {
     assert(options.type === 'application' || options.type === 'agent', 'options.type should be application or agent');
 
     super();
+
+    this[EGG_READY_TIMEOUT_ENV] = Number.parseInt(process.env.EGG_READY_TIMEOUT_ENV || 10000);
 
     /**
      * @member {Object} EggCore#_options
@@ -286,12 +289,12 @@ class EggCore extends KoaApplication {
      * const done = app.readyCallback('mysql');
      * mysql.ready(done);
      */
-    require('ready-callback')({ timeout: 10000 }).mixin(this);
+    require('ready-callback')({ timeout: this[EGG_READY_TIMEOUT_ENV] }).mixin(this);
 
     this.on('ready_stat', data => {
       this.console.info('[egg:core:ready_stat] end ready task %s, remain %j', data.id, data.remain);
     }).on('ready_timeout', id => {
-      this.console.warn('[egg:core:ready_timeout] 10 seconds later %s was still unable to finish.', id);
+      this.console.warn('[egg:core:ready_timeout] %s seconds later %s was still unable to finish.', this[EGG_READY_TIMEOUT_ENV] / 1000, id);
     });
 
     this.ready(() => debug('egg emit ready, application started'));

--- a/test/egg.test.js
+++ b/test/egg.test.js
@@ -123,8 +123,9 @@ describe('test/egg.test.js', () => {
     it('should log info when plugin is not ready', done => {
       app = utils.createApp('notready');
       app.loader.loadAll();
-      mm(app.console, 'warn', (message, a) => {
-        assert(message === '[egg:core:ready_timeout] 10 seconds later %s was still unable to finish.');
+      mm(app.console, 'warn', (message, b, a) => {
+        assert(message === '[egg:core:ready_timeout] %s seconds later %s was still unable to finish.');
+        assert(b === 10);
         assert(a === 'a');
         done();
       });
@@ -150,6 +151,7 @@ describe('test/egg.test.js', () => {
 
   describe('app.beforeStart()', () => {
     let app;
+    afterEach(mm.restore);
     afterEach(() => app.close());
 
     it('should beforeStart param error', done => {
@@ -172,6 +174,15 @@ describe('test/egg.test.js', () => {
       assert(app.beforeStartFunction === true);
       assert(app.beforeStartGeneratorFunction === true);
       assert(app.beforeStartAsyncFunction === true);
+    });
+
+    it('should beforeStart excute success with EGG_READY_TIMEOUT_ENV', function* () {
+      mm(process.env, 'EGG_READY_TIMEOUT_ENV', '12000');
+      const start = Date.now();
+      app = utils.createApp('beforestart-timeout');
+      app.loader.loadAll();
+      yield app.ready();
+      assert(Date.now() - start > 11000);
     });
 
     it('should beforeStart excute failed', done => {

--- a/test/fixtures/beforestart-with-timeout-env/app.js
+++ b/test/fixtures/beforestart-with-timeout-env/app.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const sleep = require('ko-sleep');
+module.exports = function (app) {
+  app.beforeStart(function* () {
+    yield sleep(11000);
+    app.beforeStartFunction = true;
+  });
+  app.beforeStartFunction = false;
+};
+

--- a/test/fixtures/beforestart-with-timeout-env/package.json
+++ b/test/fixtures/beforestart-with-timeout-env/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "beforestart-with-timeout-env"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
Support app timeout time config, use `EGG_READY_TIMEOUT_ENV = 20000` to config app start get timeout after 20 seconds. Default app ready will get timeout after 10 seconds.