### PR TITLE
feat: provide controllerName and actionName of the current controller…

### DIFF
--- a/lib/loader/mixin/controller.js
+++ b/lib/loader/mixin/controller.js
@@ -75,6 +75,13 @@ function wrapClass(Controller) {
     return function* classControllerMiddleware() {
       const controller = new Controller(this);
       const r = controller[key](this);
+      // provide controllerName and actionName
+      const pathName = Object.getPrototypeOf(controller).pathName;
+      const controllerName = pathName.split('.')[1];
+      controller.ctx.state.controller = {
+        actionName: key,
+        controllerName,
+      };
       // TODO: if we can check async function, then we can check it out of the middleware
       if (is.generator(r) || is.promise(r)) {
         yield r;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Provide `controllerName` and `actionName` of the current controller in the view.

- `controller.controllerName`: Returns the controller's name. For instance, `PostsController` returns `posts.`
- `controller.actionName`: Returns the name of the action this controller is processing.


```
// usage
<body class=`${controller.controllerName}_${controller.actionName}`>
```

refs：http://edgeapi.rubyonrails.org/

