### PR TITLE
fix: should ignore Object.getPrototypeOf check on null/undefined

### DIFF
--- a/lib/loader/mixin/config.js
+++ b/lib/loader/mixin/config.js
@@ -105,8 +105,9 @@ module.exports = {
 
 function setConfig(obj, filepath) {
   for (const key of Object.keys(obj)) {
-    if (Object.getPrototypeOf(obj[key]) === Object.prototype) {
-      setConfig(obj[key], filepath);
+    const val = obj[key];
+    if (val && Object.getPrototypeOf(val) === Object.prototype && Object.keys(val).length > 0) {
+      setConfig(val, filepath);
       continue;
     }
     obj[key] = filepath;

--- a/test/fixtures/configmeta/config/config.js
+++ b/test/fixtures/configmeta/config/config.js
@@ -1,12 +1,15 @@
 'use strict';
 
-const urllib = require('urllib');
+const HttpClient2 = require('urllib').HttpClient2;
+const urllib = new HttpClient2();
 
 exports.urllib = {
   keepAlive: false,
   foo: null,
   bar: undefined,
   n: 1,
+  dd: new Date(),
+  httpclient: urllib,
 };
 
 exports.buffer = new Buffer('1234');
@@ -20,3 +23,5 @@ exports.ok = true;
 exports.f = false;
 exports.no = null;
 exports.empty = {};
+exports.date = new Date();
+exports.ooooo = urllib;

--- a/test/fixtures/configmeta/config/config.js
+++ b/test/fixtures/configmeta/config/config.js
@@ -3,10 +3,20 @@
 const urllib = require('urllib');
 
 exports.urllib = {
-  keepAlive: false
+  keepAlive: false,
+  foo: null,
+  bar: undefined,
+  n: 1,
 };
 
 exports.buffer = new Buffer('1234');
 exports.array = [];
 
 exports.console = console;
+
+exports.zero = 0;
+exports.number = 1;
+exports.ok = true;
+exports.f = false;
+exports.no = null;
+exports.empty = {};

--- a/test/loader/mixin/load_config.test.js
+++ b/test/loader/mixin/load_config.test.js
@@ -5,9 +5,7 @@ const assert = require('assert');
 const utils = require('../../utils');
 const Application = require('../../..').EggCore;
 
-
 describe('test/loader/mixin/load_config.test.js', () => {
-
   let app;
   afterEach(() => app.close());
 
@@ -127,8 +125,18 @@ describe('test/loader/mixin/load_config.test.js', () => {
     assert(configMeta.console === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.array === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.buffer === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.ok === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.f === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.empty === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.zero === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.number === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.no === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.urllib.keepAlive === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.urllib.timeout === utils.getFilepath('egg/config/config.default.js'));
+    assert(configMeta.urllib.foo === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.urllib.n === utils.getFilepath('configmeta/config/config.js'));
+    // undefined will be ignore
+    assert(!configMeta.urllib.bar);
   });
 
 });

--- a/test/loader/mixin/load_config.test.js
+++ b/test/loader/mixin/load_config.test.js
@@ -131,10 +131,15 @@ describe('test/loader/mixin/load_config.test.js', () => {
     assert(configMeta.zero === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.number === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.no === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.date === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.ooooo === utils.getFilepath('configmeta/config/config.js'));
+
     assert(configMeta.urllib.keepAlive === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.urllib.timeout === utils.getFilepath('egg/config/config.default.js'));
     assert(configMeta.urllib.foo === utils.getFilepath('configmeta/config/config.js'));
     assert(configMeta.urllib.n === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.urllib.dd === utils.getFilepath('configmeta/config/config.js'));
+    assert(configMeta.urllib.httpclient === utils.getFilepath('configmeta/config/config.js'));
     // undefined will be ignore
     assert(!configMeta.urllib.bar);
   });


### PR DESCRIPTION
bugfix for https://github.com/eggjs/egg-core/pull/106

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
