### PR TITLE
feat: controller support params by config

### DIFF
--- a/lib/loader/mixin/controller.js
+++ b/lib/loader/mixin/controller.js
@@ -74,7 +74,10 @@ function wrapClass(Controller) {
   function methodToMiddleware(Controller, key) {
     return function* classControllerMiddleware(...args) {
       const controller = new Controller(this);
-      return yield callController(controller[key], this, args, controller);
+      if (!this.app.config.controller || !this.app.config.controller.supportParams) {
+        args = [ this ];
+      }
+      return yield callController(controller[key], controller, args);
     };
   }
 }
@@ -98,6 +101,9 @@ function wrapObject(obj, path) {
 
   function functionToMiddleware(func) {
     const objectControllerMiddleware = function* (...args) {
+      if (!this.app.config.controller || !this.app.config.controller.supportParams) {
+        args = [ this ];
+      }
       return yield callController(func, this, args);
     };
     for (const key in func) {
@@ -107,16 +113,8 @@ function wrapObject(obj, path) {
   }
 }
 
-function* callController(func, ctx, args, controller) {
-  // class controller's context is controller
-  // object controller's context is ctx(egg Context's instance)
-  const context = controller || ctx;
-  let r;
-  if (ctx.app.config.controller && ctx.app.config.controller.supportParams) {
-    r = func.call(context, ...args);
-  } else {
-    r = func.call(context, ctx);
-  }
+function* callController(func, ctx, args) {
+  const r = func.call(ctx, ...args);
   if (is.generator(r) || is.promise(r)) {
     return yield r;
   }

--- a/lib/loader/mixin/controller.js
+++ b/lib/loader/mixin/controller.js
@@ -72,13 +72,9 @@ function wrapClass(Controller) {
   return ret;
 
   function methodToMiddleware(Controller, key) {
-    return function* classControllerMiddleware() {
+    return function* classControllerMiddleware(...args) {
       const controller = new Controller(this);
-      const r = controller[key](this);
-      // TODO: if we can check async function, then we can check it out of the middleware
-      if (is.generator(r) || is.promise(r)) {
-        yield r;
-      }
+      return yield callController(controller[key], this, args, controller);
     };
   }
 }
@@ -101,15 +97,28 @@ function wrapObject(obj, path) {
   return ret;
 
   function functionToMiddleware(func) {
-    const objectControllerMiddleware = function* () {
-      const r = func.call(this, this);
-      if (is.generator(r) || is.promise(r)) {
-        yield r;
-      }
+    const objectControllerMiddleware = function* (...args) {
+      return yield callController(func, this, args);
     };
     for (const key in func) {
       objectControllerMiddleware[key] = func[key];
     }
     return objectControllerMiddleware;
   }
+}
+
+function* callController(func, ctx, args, controller) {
+  // class controller's context is controller
+  // object controller's context is ctx(egg Context's instance)
+  const context = controller || ctx;
+  let r;
+  if (ctx.app.config.controller && ctx.app.config.controller.supportParams) {
+    r = func.call(context, ...args);
+  } else {
+    r = func.call(context, ctx);
+  }
+  if (is.generator(r) || is.promise(r)) {
+    return yield r;
+  }
+  return r;
 }

--- a/test/fixtures/controller-params/app/controller/class.js
+++ b/test/fixtures/controller-params/app/controller/class.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};
+module.exports = class HomeController {
+
+  constructor(ctx) {
+    this.ctx = ctx;
+  }
+
+  * callFunction(...args) {
+    this.ctx.body = 'done';
+    return args;
+  }
+};

--- a/test/fixtures/controller-params/app/controller/generator_function.js
+++ b/test/fixtures/controller-params/app/controller/generator_function.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function* (...args) {
+  this.body = 'done';
+  return args;
+};

--- a/test/fixtures/controller-params/app/controller/object.js
+++ b/test/fixtures/controller-params/app/controller/object.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  * callFunction(...args) {
+    this.body = 'done';
+    return args;
+  },
+};

--- a/test/fixtures/controller-params/app/router.js
+++ b/test/fixtures/controller-params/app/router.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/generator-function', 'generatorFunction');
+  app.get('/object-function', 'object.callFunction');
+  app.get('/class-function', 'class.callFunction');
+};

--- a/test/fixtures/controller-params/config/config.default.js
+++ b/test/fixtures/controller-params/config/config.default.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.controller = {
+  supportParams: true,
+};

--- a/test/fixtures/controller-params/package.json
+++ b/test/fixtures/controller-params/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "controller-params"
+}

--- a/test/loader/mixin/load_controller.test.js
+++ b/test/loader/mixin/load_controller.test.js
@@ -260,4 +260,40 @@ describe('test/loader/mixin/load_controller.test.js', () => {
       assert(app.controller.user);
     });
   });
+
+  describe('when controller.supportParams === true', () => {
+    let app;
+    before(() => {
+      app = utils.createApp('controller-params');
+      app.loader.loadAll();
+      return app.ready();
+    });
+    after(() => app.close());
+
+    it('should use as controller', function* () {
+      yield request(app.callback())
+        .get('/generator-function')
+        .expect(200)
+        .expect('done');
+      yield request(app.callback())
+        .get('/class-function')
+        .expect(200)
+        .expect('done');
+      yield request(app.callback())
+        .get('/object-function')
+        .expect(200)
+        .expect('done');
+    });
+
+    it('should support parameter', function* () {
+      const ctx = { app };
+      const args = [ 1, 2, 3 ];
+      let r = yield app.controller.generatorFunction.call(ctx, ...args);
+      assert.deepEqual(args, r);
+      r = yield app.controller.object.callFunction.call(ctx, ...args);
+      assert.deepEqual(args, r);
+      r = yield app.controller.class.callFunction.call(ctx, ...args);
+      assert.deepEqual(args, r);
+    });
+  });
 });

--- a/test/loader/mixin/load_service.test.js
+++ b/test/loader/mixin/load_service.test.js
@@ -14,6 +14,7 @@ describe('test/loader/mixin/load_service.test.js', function() {
   it('should load from application and plugin', function* () {
     app = utils.createApp('plugin');
     app.loader.loadPlugin();
+    app.loader.loadConfig();
     app.loader.loadApplicationExtend();
     app.loader.loadService();
     app.loader.loadController();
@@ -41,6 +42,7 @@ describe('test/loader/mixin/load_service.test.js', function() {
     assert.throws(() => {
       app = utils.createApp('service-override');
       app.loader.loadPlugin();
+      app.loader.loadConfig();
       app.loader.loadService();
     }, /can't overwrite property 'foo'/);
   });
@@ -48,6 +50,7 @@ describe('test/loader/mixin/load_service.test.js', function() {
   it('should check es6', function() {
     app = utils.createApp('services_loader_verify');
     app.loader.loadPlugin();
+    app.loader.loadConfig();
     app.loader.loadApplicationExtend();
     app.loader.loadService();
     assert('foo' in app.serviceClasses);
@@ -59,6 +62,7 @@ describe('test/loader/mixin/load_service.test.js', function() {
   it('should each request has unique ctx', function* () {
     app = utils.createApp('service-unique');
     app.loader.loadPlugin();
+    app.loader.loadConfig();
     app.loader.loadApplicationExtend();
     app.loader.loadService();
     app.loader.loadController();
@@ -78,6 +82,7 @@ describe('test/loader/mixin/load_service.test.js', function() {
   it('should extend app.Service', function* () {
     app = utils.createApp('extends-app-service');
     app.loader.loadPlugin();
+    app.loader.loadConfig();
     app.loader.loadApplicationExtend();
     app.loader.loadService();
     app.loader.loadController();
@@ -97,6 +102,7 @@ describe('test/loader/mixin/load_service.test.js', function() {
       mm(process.env, 'NO_DEPRECATION', '*');
       app = utils.createApp('subdir-services');
       app.loader.loadPlugin();
+      app.loader.loadConfig();
       app.loader.loadApplicationExtend();
       app.loader.loadService();
       app.loader.loadController();


### PR DESCRIPTION
- `app.config.controller.supportParams` to enable
- support return controller's returned value

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

controller

##### Description of change
<!-- Provide a description of the change below this comment. -->

- controller support params, `app.config.controller.supportParams` to enable
- support return controller's returned value

The only recommended controller format is controller class, generator function is for backward compatibility, `ctx` as the first arguments should be deprecate in the next major version and will be removed in documents.