### PR TITLE
fix TypeError when DEBUG=*

### DIFF
--- a/lib/loader/egg_loader.js
+++ b/lib/loader/egg_loader.js
@@ -27,7 +27,6 @@ class EggLoader {
     assert(fs.existsSync(this.options.baseDir), `${this.options.baseDir} not exists`);
     assert(this.options.app, 'options.app is required');
     assert(this.options.logger, 'options.logger is required');
-    debug('EggLoader options %j', options);
 
     this.app = this.options.app;
 


### PR DESCRIPTION
```js
      if (this.config.httpclient.enableDNSCache) {
                                ^

TypeError: Cannot read property 'enableDNSCache' of undefined
    at Agent.get httpclient [as httpclient] (/Users/jacksontian/git/npp-console/node_modules/.1.7.0@egg/lib/egg.js:246:33)
    at abbr (/Users/jacksontian/git/npp-console/node_modules/.1.7.0@egg/lib/egg.js:170:17)
    at Agent.inspect (/Users/jacksontian/git/npp-console/node_modules/.1.7.0@egg/lib/egg.js:182:5)
    at formatValue (util.js:372:36)
    at inspect (util.js:236:10)
    at format (util.js:97:24)
    at Console.log (console.js:113:24)
    at AgentWorkerLoader.EggLoader (/Users/jacksontian/git/npp-console/node_modules/.3.13.0@egg-core/lib/loader/egg_loader.js:34:13)
    at AgentWorkerLoader (/Users/jacksontian/git/npp-console/node_modules/.1.7.0@egg/lib/loader/agent_worker_loader.js:9:1)
```

In current stage, the config is not finished.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
