### PR TITLE
每个请求添加 controllerName 和 actionName 属性

### DIFF
--- a/lib/loader/mixin/controller.js
+++ b/lib/loader/mixin/controller.js
@@ -36,7 +36,7 @@ module.exports = {
           return wrapClass(obj);
         }
         if (is.object(obj)) {
-          return wrapObject(obj, opt.path);
+          return wrapObject(obj, opt);
         }
         if (is.generatorFunction(obj)) {
           return wrapObject({ 'module.exports': obj }, opt.path)['module.exports'];
@@ -66,40 +66,44 @@ function wrapClass(Controller) {
     // skip getter, setter & non-function properties
     const d = Object.getOwnPropertyDescriptor(proto, key);
     if (is.function(d.value)) {
-      ret[key] = methodToMiddleware(Controller, key);
+      ret[key] = methodToMiddleware(Controller, proto.pathName, key);
     }
   }
   return ret;
 
-  function methodToMiddleware(Controller, key) {
-    return function* classControllerMiddleware(...args) {
+  function methodToMiddleware(Controller, controllerName, actionName) {
+    const classControllerMiddleware = function* classControllerMiddleware(...args) {
       const controller = new Controller(this);
       if (!this.app.config.controller || !this.app.config.controller.supportParams) {
         args = [ this ];
       }
-      return yield callController(controller[key], controller, args);
+      return yield callController(controller[actionName], controller, args);
     };
+
+    classControllerMiddleware.controllerName = formatControllerName(controllerName);
+    classControllerMiddleware.actionName = actionName;
+    return classControllerMiddleware;
   }
 }
 
 // wrap the method of the object, method can receive ctx as it's first argument
-function wrapObject(obj, path) {
+function wrapObject(obj, opt) {
   const keys = Object.keys(obj);
   const ret = {};
   for (const key of keys) {
     if (is.function(obj[key])) {
       const names = utility.getParamNames(obj[key]);
       if (names[0] === 'next') {
-        throw new Error(`controller \`${key}\` should not use next as argument from file ${path}`);
+        throw new Error(`controller \`${key}\` should not use next as argument from file ${opt.path}`);
       }
-      ret[key] = functionToMiddleware(obj[key]);
+      ret[key] = functionToMiddleware(obj[key], opt.pathName, key);
     } else if (is.object(obj[key])) {
       ret[key] = wrapObject(obj[key], path);
     }
   }
   return ret;
 
-  function functionToMiddleware(func) {
+  function functionToMiddleware(func, controllerName, actionName) {
     const objectControllerMiddleware = function* (...args) {
       if (!this.app.config.controller || !this.app.config.controller.supportParams) {
         args = [ this ];
@@ -109,6 +113,8 @@ function wrapObject(obj, path) {
     for (const key in func) {
       objectControllerMiddleware[key] = func[key];
     }
+    objectControllerMiddleware.controllerName = formatControllerName(controllerName);
+    objectControllerMiddleware.actionName = actionName;
     return objectControllerMiddleware;
   }
 }
@@ -119,4 +125,12 @@ function* callController(func, ctx, args) {
     return yield r;
   }
   return r;
+}
+
+function formatControllerName(name) {
+  let splits = name.split('.');
+  if (splits[0] === 'controller') {
+    splits = splits.slice(1);
+  }
+  return splits.join('.');
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
由于每个请求目前很难得到当前所对应的 `controller` 和 `action`，在很多场景是需要这两个属性的，比如统计之类的，把 `controllerName` 和 `actionName` 挂载到返回的包装函数上，在应用中可以在 middleware 中自行处理
```javascript
module.exports = options => {
  return function* router(next) {
    const routerMatchd = this.router.match(this.path, this.method);
    if (routerMatchd) {
      const router = routerMatchd.pathAndMethod[0];
      const stack = router.stack[router.stack.length - 1];
      console.log('------------------------------------');
      console.log('stack', stack.controllerName, stack.actionName);
      console.log('------------------------------------');
    }
    yield next;
  }
}
```
