### PR TITLE
feat(core): adding support to register inherited methods when loading controllers

### DIFF
--- a/lib/loader/mixin/controller.js
+++ b/lib/loader/mixin/controller.js
@@ -54,20 +54,25 @@ module.exports = {
 
 // wrap the class, yield a object with middlewares
 function wrapClass(Controller) {
-  const proto = Controller.prototype;
-  const keys = Object.getOwnPropertyNames(proto);
+  let proto = Controller.prototype;
   const ret = {};
-  for (const key of keys) {
-    // getOwnPropertyNames will return constructor
-    // that should be ignored
-    if (key === 'constructor') {
-      continue;
+  // tracing the prototype chain
+  while (proto !== Object.prototype) {
+    const keys = Object.getOwnPropertyNames(proto);
+    for (const key of keys) {
+      // getOwnPropertyNames will return constructor
+      // that should be ignored
+      if (key === 'constructor') {
+        continue;
+      }
+      // skip getter, setter & non-function properties
+      const d = Object.getOwnPropertyDescriptor(proto, key);
+      // prevent to override sub method
+      if (is.function(d.value) && !ret.hasOwnProperty(key)) {
+        ret[key] = methodToMiddleware(Controller, key);
+      }
     }
-    // skip getter, setter & non-function properties
-    const d = Object.getOwnPropertyDescriptor(proto, key);
-    if (is.function(d.value)) {
-      ret[key] = methodToMiddleware(Controller, key);
-    }
+    proto = Object.getPrototypeOf(proto);
   }
   return ret;
 

--- a/test/fixtures/controller-app/app/controller/class_inherited.js
+++ b/test/fixtures/controller-app/app/controller/class_inherited.js
@@ -1,0 +1,21 @@
+'use strict';
+
+class BaseController {
+  constructor(ctx) {
+    this.ctx = ctx;
+  }
+
+  callInheritedFunction() {
+    this.ctx.body = 'inherited';
+  }
+
+  callOverriddenFunction() {
+    this.ctx.body = 'base';
+  }
+}
+
+module.exports = class HomeController extends BaseController {
+  callOverriddenFunction() {
+    this.ctx.body = 'own';
+  }
+};

--- a/test/fixtures/controller-app/app/router.js
+++ b/test/fixtures/controller-app/app/router.js
@@ -16,6 +16,9 @@ module.exports = app => {
   app.get('/class-async-function', 'class.callAsyncFunction');
   app.get('/class-async-function-arg', 'class.callAsyncFunctionWithArg');
 
+  app.get('/class-inherited-function', 'classInherited.callInheritedFunction');
+  app.get('/class-overridden-function', 'classInherited.callOverriddenFunction');
+
   app.get('/class-wrap-function', 'classWrapFunction.get');
   app.get('/class-pathname', 'admin.config.getName');
   app.get('/class-fullpath', 'admin.config.getFullPath');

--- a/test/loader/mixin/load_controller.test.js
+++ b/test/loader/mixin/load_controller.test.js
@@ -165,6 +165,20 @@ describe('test/loader/mixin/load_controller.test.js', () => {
         .expect('done');
     });
 
+    it('should load class that is inherited from its super class', () => {
+      return request(app.callback())
+        .get('/class-inherited-function')
+        .expect(200)
+        .expect('inherited');
+    });
+
+    it('should load inherited class without overriding its own function', () => {
+      return request(app.callback())
+        .get('/class-overridden-function')
+        .expect(200)
+        .expect('own');
+    });
+
     it('should not load properties that are not function', () => {
       assert(!app.controller.class.nofunction);
     });


### PR DESCRIPTION
feat(core): adding support to register inherited methods when loading controllers

Closes eggjs/egg#1527

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
