### PR TITLE
styles: replace `indexOf()` with `includes()`

### DIFF
--- a/lib/loader/egg_loader.js
+++ b/lib/loader/egg_loader.js
@@ -259,7 +259,7 @@ class EggLoader {
       const eggPath = proto[Symbol.for('egg#eggPath')];
       assert(eggPath && typeof eggPath === 'string', 'Symbol.for(\'egg#eggPath\') should be string');
       const realpath = fs.realpathSync(eggPath);
-      if (eggPaths.indexOf(realpath) === -1) {
+      if (!eggPaths.includes(realpath)) {
         eggPaths.unshift(realpath);
       }
     }

--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -108,7 +108,7 @@ module.exports = {
       this.mergePluginConfig(plugin);
 
       // disable the plugin that not match the serverEnv
-      if (env && plugin.env.length && plugin.env.indexOf(env) === -1) {
+      if (env && plugin.env.length && !plugin.env.includes(env)) {
         this.options.logger.info('Plugin %s is disabled by env unmatched, require env(%s) but got env is %s', name, plugin.env, env);
         plugin.enable = false;
         continue;
@@ -266,7 +266,7 @@ module.exports = {
       for (const missName of result.missingTasks) {
         const requires = [];
         for (const name in allPlugins) {
-          if (allPlugins[name].dependencies.indexOf(missName) >= 0) {
+          if (allPlugins[name].dependencies.includes(missName)) {
             requires.push(name);
           }
         }

--- a/lib/utils/router.js
+++ b/lib/utils/router.js
@@ -210,7 +210,7 @@ class Router extends KoaRouter {
       });
 
       for (const key in args) {
-        if (replacedParams.indexOf(key) !== -1) {
+        if (replacedParams.includes(key)) {
           continue;
         }
 
@@ -228,7 +228,7 @@ class Router extends KoaRouter {
 
     if (queries.length > 0) {
       const queryStr = queries.join('&');
-      if (url.indexOf('?') === -1) {
+      if (!url.includes('?')) {
         url = `${url}?${queryStr}`;
       } else {
         url = `${url}&${queryStr}`;

--- a/lib/utils/sequencify.js
+++ b/lib/utils/sequencify.js
@@ -2,7 +2,7 @@
 
 function sequence(tasks, names, results, missing, recursive, nest, optional) {
   names.forEach(function(name) {
-    if (results.indexOf(name) !== -1) {
+    if (results.includes(name)) {
       return; // de-dup results
     }
     const node = tasks[name];
@@ -16,7 +16,7 @@ function sequence(tasks, names, results, missing, recursive, nest, optional) {
 
     if (!node) {
       missing.push(name);
-    } else if (nest.indexOf(name) > -1) {
+    } else if (nest.includes(name)) {
       nest.push(name);
       recursive.push(nest.slice(0));
       nest.pop(name);

--- a/test/egg.test.js
+++ b/test/egg.test.js
@@ -73,7 +73,7 @@ describe('test/egg.test.js', () => {
         });
         throw new Error('should not run');
       } catch (err) {
-        assert(err.message.indexOf(`Directory ${__filename} is not a directory`) >= 0);
+        assert(err.message.includes(`Directory ${__filename} is not a directory`));
       }
     });
 
@@ -213,7 +213,7 @@ describe('test/egg.test.js', () => {
       app.loader.loadAll();
       app.once('ready_timeout', id => {
         const file = path.normalize('test/fixtures/beforestart-with-timeout-env/app.js');
-        assert(id.indexOf(file) >= 0);
+        assert(id.includes(file));
         done();
       });
     });
@@ -243,7 +243,7 @@ describe('test/egg.test.js', () => {
       app.loader.loadAll();
       app.once('ready_timeout', id => {
         const file = path.normalize('test/fixtures/beforestart-timeout/app.js');
-        assert(id.indexOf(file) >= 0);
+        assert(id.includes(file));
         done();
       });
     });

--- a/test/loader/get_appname.test.js
+++ b/test/loader/get_appname.test.js
@@ -19,7 +19,7 @@ describe('test/loader/get_appname.test.js', () => {
     try {
       utils.createApp('app-noname');
     } catch (err) {
-      assert(err.message.indexOf(`name is required from ${pkg}`) >= 0);
+      assert(err.message.includes(`name is required from ${pkg}`));
       done();
     }
   });

--- a/test/loader/mixin/load_config.test.js
+++ b/test/loader/mixin/load_config.test.js
@@ -80,7 +80,7 @@ describe('test/loader/mixin/load_config.test.js', () => {
       loader.loadConfig();
       throw new Error('should not run');
     } catch (err) {
-      assert(err.message.indexOf(`Can not define middleware in ${path.join(pluginDir, 'config/config.default.js')}`) >= 0);
+      assert(err.message.includes(`Can not define middleware in ${path.join(pluginDir, 'config/config.default.js')}`));
     }
   });
 

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -323,7 +323,7 @@ describe('test/load_plugin.test.js', function() {
     const plugins = loader.orderPlugins.map(function(plugin) {
       return plugin.name;
     });
-    assert(plugins.indexOf('testMe') === -1);
+    assert(!plugins.includes('testMe'));
   });
 
   it('should complement infomation by config/plugin.js from plugin', function() {
@@ -339,7 +339,7 @@ describe('test/load_plugin.test.js', function() {
     const keys1 = loader1.orderPlugins.map(function(plugin) {
       return plugin.name;
     }).join(',');
-    assert(keys1.indexOf('b,c,d1,f,e') > -1);
+    assert(keys1.includes('b,c,d1,f,e'));
     assert(!loader1.plugins.a1);
 
     mm(process.env, 'NODE_ENV', 'development');
@@ -350,7 +350,7 @@ describe('test/load_plugin.test.js', function() {
     const keys2 = loader2.orderPlugins.map(function(plugin) {
       return plugin.name;
     }).join(',');
-    assert(keys2.indexOf('d1,a1,b,c,f,e') > -1);
+    assert(keys2.includes('d1,a1,b,c,f,e'));
     assert.deepEqual(loader2.plugins.a1, {
       enable: true,
       name: 'a1',

--- a/test/utils/router.test.js
+++ b/test/utils/router.test.js
@@ -205,7 +205,7 @@ describe('test/utils/router.test.js', () => {
 
   describe('router.method', () => {
     it('router method include HEAD', () => {
-      assert(app.router.methods.indexOf('HEAD') > -1);
+      assert(app.router.methods.includes('HEAD'));
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

All the subsystems and tests using `indexOf()`.

##### Description of change
<!-- Provide a description of the change below this comment. -->

nodej.s version is 8 / 9 in `.travis.yml` , so I make some changes to make code more readable by using ES6 features. The rules that I used: 

+ replace `indexOf() !== -1` with `includes()`
+ replace `indexOf() >= 0` with `includes()`
+ replace `indexOf() > -1` with `includes()`
+ replace  `indexOf() === -1` with `!includes()`