### PR TITLE
fix: plugin loader fault tolerance mechanism is too strict

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -289,6 +289,9 @@ module.exports = {
       }
 
       if (!allPlugins[name].enable) {
+        if (allPlugins[name].notFound) {
+          throw allPlugins[name].notFound;
+        }
         implicitEnabledPlugins.push(name);
         allPlugins[name].enable = true;
       }
@@ -346,7 +349,13 @@ module.exports = {
       }
     }
 
-    throw new Error(`Can not find plugin ${name} in "${lookupDirs.join(', ')}"`);
+    const err = new Error(`Can not find plugin ${name} in "${lookupDirs.join(', ')}"`);
+    if (!plugin.enable) {
+      plugin.notFound = err;
+      return '[not Found]';
+    }
+
+    throw err;
   },
 
   _extendPlugins(target, plugins) {

--- a/test/fixtures/load-plugin-default/config/plugin.default.js
+++ b/test/fixtures/load-plugin-default/config/plugin.default.js
@@ -6,3 +6,5 @@ exports.c = {
   enable: true,
   path: path.join(__dirname, '../plugins/c'),
 }
+
+exports.bcdef = false;

--- a/test/fixtures/no-dep-plugin/config/plugin.js
+++ b/test/fixtures/no-dep-plugin/config/plugin.js
@@ -9,7 +9,7 @@ module.exports = {
   },
 
   customB: {
-    enable: false,
+    enable: true,
     package: '@ali/b',
   },
 };

--- a/test/fixtures/plugin-dep-disable-and-missing/config/plugin.js
+++ b/test/fixtures/plugin-dep-disable-and-missing/config/plugin.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.e = false;

--- a/test/fixtures/plugin-dep-disable-and-missing/framework/config/plugin.js
+++ b/test/fixtures/plugin-dep-disable-and-missing/framework/config/plugin.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  a: {
+    enable: true,
+    path: path.join(__dirname, '../plugins/a'),
+  },
+
+  b: {
+    enable: false,
+    path: path.join(__dirname, '../plugins/b'),
+  },
+
+  c: {
+    enable: false,
+    path: path.join(__dirname, '../plugins/c'),
+  },
+
+  d: {
+    enable: true,
+    path: path.join(__dirname, '../plugins/d'),
+  },
+
+  e: {
+    enable: true,
+  },
+};

--- a/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/a/package.json
+++ b/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "a",
+  "eggPlugin": {
+    "name": "a",
+    "dep": ["b", "c"]
+  }
+}

--- a/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/b/package.json
+++ b/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "b",
+  "eggPlugin": {
+    "name": "b"
+  }
+}

--- a/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/c/package.json
+++ b/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/c/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "c",
+  "eggPlugin": {
+    "name": "c",
+    "dep": [ "e" ]
+  }
+}

--- a/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/d/package.json
+++ b/test/fixtures/plugin-dep-disable-and-missing/framework/plugins/d/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "d",
+  "eggPlugin": {
+    "name": "d",
+    "dep": ["b"]
+  }
+}

--- a/test/fixtures/plugin-dep-disable-and-missing/package.json
+++ b/test/fixtures/plugin-dep-disable-and-missing/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "plugin-dep-missing"
+}

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -314,6 +314,23 @@ describe('test/load_plugin.test.js', function() {
     assert(!loader.plugins.e);
   });
 
+  it('should throw error when dependency plugin disabled and missing', () => {
+    class Application extends EggCore {
+      get [Symbol.for('egg#eggPath')]() {
+        return utils.getFilepath('plugin-dep-disable-and-missing/framework');
+      }
+    }
+
+    assert.throws(() => {
+      app = utils.createApp('plugin-dep-disable-and-missing', {
+        Application,
+      });
+      const loader = app.loader;
+      loader.loadPlugin();
+      loader.loadConfig();
+    }, /Can not find plugin e in /);
+  });
+
   it('should enable when not match env', function() {
     app = utils.createApp('dont-load-plugin');
     const loader = app.loader;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
plugin

##### Description of change
<!-- Provide a description of the change below this comment. -->

修正 Plugin Load 在路径判断时候太严谨的问题。

原逻辑为，若一个插件并不存在，那么无论插件在配置中是否为 `false`，都会抛出插件无法找到的异常。

现在的逻辑如下：

+ 如果一个插件并不存在，并且在配置中被配置成 `false`，则跳过路径检查并不会抛出异常；
+ 在上述基础上，若该插件为另一个插件的依赖，并在 `getOrderPlugins` 阶段时被判定需要被开启，此时才会抛出路径检查的异常。