### PR TITLE
feat: change assert to warning

### DIFF
--- a/lib/loader/egg_loader.js
+++ b/lib/loader/egg_loader.js
@@ -30,6 +30,10 @@ class EggLoader {
     assert(this.options.app, 'options.app is required');
     assert(this.options.logger, 'options.logger is required');
 
+    if (options.typescript && !require.extensions['.ts']) {
+      this.options.logger.warn('[egg:loader] `require.extensions` should contains `.ts` while `options.typescript` was true');
+    }
+
     this.app = this.options.app;
 
     /**

--- a/lib/loader/file_loader.js
+++ b/lib/loader/file_loader.js
@@ -50,9 +50,6 @@ class FileLoader {
   constructor(options) {
     assert(options.directory, 'options.directory is required');
     assert(options.target, 'options.target is required');
-    if (options.typescript) {
-      assert(require.extensions['.ts'], '`require.extensions` should contains `.ts` while `options.typescript` was true');
-    }
     this.options = Object.assign({}, defaults, options);
 
     // compatible old options _lowercaseFirst_
@@ -127,7 +124,7 @@ class FileLoader {
   parse() {
     let files = this.options.match;
     if (!files) {
-      files = this.options.typescript
+      files = (this.options.typescript && require.extensions['.ts'])
         ? [ '**/*.(js|ts)', '!**/*.d.ts' ]
         : [ '**/*.js' ];
     } else {

--- a/test/egg-ts.test.js
+++ b/test/egg-ts.test.js
@@ -7,11 +7,11 @@ const utils = require('./utils');
 describe('test/egg-ts.test.js', () => {
   let app;
 
-  before(() => {
+  beforeEach(() => {
     require.extensions['.ts'] = require.extensions['.js'];
   });
 
-  after(() => {
+  afterEach(() => {
     delete require.extensions['.ts'];
   });
 
@@ -78,6 +78,17 @@ describe('test/egg-ts.test.js', () => {
 
   it('should not load ts files while typescript was false', async () => {
     app = utils.createApp('egg-ts-js');
+
+    app.loader.loadApplicationExtend();
+    app.loader.loadService();
+    assert(!app.appExtend);
+    assert(app.serviceClasses.lord);
+    assert(!app.serviceClasses.test);
+  });
+
+  it('should not load ts files while typescript was true but no extensions', async () => {
+    delete require.extensions['.ts'];
+    app = utils.createApp('egg-ts-js', { typescript: true });
 
     app.loader.loadApplicationExtend();
     app.loader.loadService();

--- a/test/loader/egg_loader.test.js
+++ b/test/loader/egg_loader.test.js
@@ -39,5 +39,13 @@ describe('test/loader/egg_loader.test.js', () => {
       mm(process.env, 'EGG_HOME', '/path/to/home');
       assert(app.loader.getHomedir() === '/path/to/home');
     });
+
+    it('should warning when typescript was true but no ts extension', done => {
+      mm(process.stdout, 'write', msg => {
+        assert(msg.includes('`require.extensions` should contains `.ts` while `options.typescript` was true'));
+        done();
+      });
+      utils.createApp('nothing', { typescript: true });
+    });
   });
 });

--- a/test/loader/file_loader.test.js
+++ b/test/loader/file_loader.test.js
@@ -254,17 +254,6 @@ describe('test/loader/file_loader.test.js', () => {
     }, /_private is not match 'a-z0-9_-' in _private.js/);
   });
 
-  it('should throw when typescript was true but no ts extension', () => {
-    const mod = {};
-    assert.throws(() => {
-      new FileLoader({
-        directory: path.join(dirBase, 'error/dotdir'),
-        target: mod,
-        typescript: true,
-      }).load();
-    }, /`require.extensions` should contains `.ts` while `options.typescript` was true/);
-  });
-
   describe('caseStyle', () => {
     it('should load when caseStyle = upper', () => {
       const target = {};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

此前在 fileloader 中，如果 typescript 为 true，并且没有 `require.extensions['.ts']` 的时候，使用 assert 直接抛异常。

但是由于 egg-bin 的配置会在 package.json 中拿 typescript 的配置，因此导致打生产包的时候，想通过 tsc 生成 js 文件，但是此时又 package.json 中 typescript 配置又为 true 的情况下，会导致 egg-mock 实例化出来的 egg 直接因为上面那个 assert 而抛异常。

现在改成 warning，并且 file loader 在设置 match 的时候，只有 typescript 为 true 并且 require.extensions['.ts'] 存在的情况下才会 load ts