### PR TITLE
fix: toAsyncFunction can't pass is.asyncFunction()

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -344,10 +344,14 @@ class EggCore extends KoaApplication {
   /**
    * use co to wrap generator function to a function return promise
    * @param  {GeneratorFunction} fn input function
-   * @return {Function} function return promise
+   * @return {AsyncFunction} async function return promise
    */
   toAsyncFunction(fn) {
-    return is.generatorFunction(fn) ? co.wrap(fn) : fn;
+    if (!is.generatorFunction(fn)) return fn;
+    fn = co.wrap(fn);
+    return async function(...args) {
+      return fn.apply(this, args);
+    };
   }
 
   /**

--- a/test/egg.test.js
+++ b/test/egg.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const mm = require('mm');
+const is = require('is-type-of');
 const util = require('util');
 const path = require('path');
 const assert = require('assert');
@@ -404,6 +405,7 @@ describe('test/egg.test.js', () => {
         return arg;
       };
       const wrapped = app.toAsyncFunction(fn);
+      assert(is.asyncFunction(wrapped));
       return wrapped(true).then(res => assert(res === true));
     });
 

--- a/test/egg.test.js
+++ b/test/egg.test.js
@@ -402,11 +402,12 @@ describe('test/egg.test.js', () => {
 
     it('translate generator function', () => {
       const fn = function* (arg) {
+        assert.deepEqual(this, { foo: 'bar' });
         return arg;
       };
       const wrapped = app.toAsyncFunction(fn);
       assert(is.asyncFunction(wrapped));
-      return wrapped(true).then(res => assert(res === true));
+      return wrapped.call({ foo: 'bar' }, true).then(res => assert(res === true));
     });
 
     it('not translate common function', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

`app.toAsyncFunction()` returns a result that cannot pass `is.asyncFunction()`.

> `is` is [is-type-of](http://web.npm.alibaba-inc.com/package/is-type-of).