### PR TITLE
fix(plugin loader): load plugin in npm flattened dependencies tree

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -334,6 +334,7 @@ module.exports = {
     // 尝试在以下目录找到匹配的插件
     //  -> {APP_PATH}/node_modules
     //    -> {EGG_PATH}/node_modules
+    //    -> {EGG_PATH}/../
     //      -> $CWD/node_modules
     lookupDirs.push(path.join(this.options.baseDir, 'node_modules'));
 
@@ -341,6 +342,9 @@ module.exports = {
     for (let i = this.eggPaths.length - 1; i >= 0; i--) {
       const eggPath = this.eggPaths[i];
       lookupDirs.push(path.join(eggPath, 'node_modules'));
+      // egg's dependencies maybe not in {EGG_PATH}/node_modules, but in {EGG_PATH}/../
+      // see http://npm.github.io/how-npm-works-docs/npm3/how-npm3-works.html
+      lookupDirs.push(path.join(eggPath, '../'));
     }
 
     // should find the $cwd/node_modules when test the plugins under npm3


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

try to find plugin in `EGG_PATH/node_modules` and `EGG_PATH/../`.

##### The problem I got

can't load buildin plugin like `egg-onerror` in test case of `egg-script`:

```bash
npm -v
# 5.6.0
node -v
# 8.11.3
yarn -v
# 1.7.0
git clone git@github.com:eggjs/egg-scripts.git
cd egg-scripts
npm install # yarn install
npm test
```
couldn't pass test case: test/egg-scripts.test.js -> start without daemon -> without baseDir, error:

```
➜  egg-scripts git:(master) ✗ npm test

> egg-scripts@2.6.0 test /Users/fake/code/egg-scripts
> npm run lint -- --fix && npm run pkgfiles && npm run test-local


> egg-scripts@2.6.0 lint /Users/fake/code/egg-scripts
> eslint . "--fix"


> egg-scripts@2.6.0 pkgfiles /Users/fake/code/egg-scripts
> egg-bin pkgfiles


> egg-scripts@2.6.0 test-local /Users/fake/code/egg-scripts
> egg-bin test



  test/egg-scripts.test.js
    ✓ show help (353ms)

  test/start.test.js
    start without daemon
      full path
        ✓ should start (10043ms)
cleanup: 1 to kill
cleanup master 2910
      relative path
        ✓ should start (10029ms)
cleanup: 1 to kill
cleanup master 2931
      without baseDir
[egg-scripts] Starting custom-framework application at /Users/fake/code/egg-scripts/test/fixtures/example
[egg-scripts] Run node /Users/fake/code/egg-scripts/lib/start-cluster {"workers":2,"title":"egg-server-example","framework":"/Users/fake/code/egg-scripts/test/fixtures/example/node_modules/custom-framework","baseDir":"/Users/fake/code/egg-scripts/test/fixtures/example"} --title=egg-server-example
2018-07-09 02:03:30,039 INFO 2953 [master] =================== custom-framework start =====================
2018-07-09 02:03:30,041 INFO 2953 [master] node version v8.11.3
2018-07-09 02:03:30,041 INFO 2953 [master] custom-framework version 1.0.0
2018-07-09 02:03:30,041 INFO 2953 [master] start with options:
{
  "framework": "/Users/fake/code/egg-scripts/test/fixtures/example/node_modules/custom-framework",
  "baseDir": "/Users/fake/code/egg-scripts/test/fixtures/example",
  "workers": 2,
  "plugins": null,
  "https": false,
  "key": "",
  "cert": "",
  "title": "egg-server-example"
}
2018-07-09 02:03:30,042 INFO 2953 [master] start with env: isProduction: true, EGG_SERVER_ENV: undefined, NODE_ENV: production
2018-07-09 02:03:30,053 INFO 2953 [master] agent_worker#1:2954 start with clusterPort:51371
/Users/fake/code/egg-scripts/node_modules/egg-core/lib/loader/mixin/plugin.js:354
    throw new Error(`Can not find plugin ${name} in "${lookupDirs.join(', ')}"`);
    ^

Error: Can not find plugin egg-onerror in "/Users/fake/code/egg-scripts/test/fixtures/example/node_modules, /Users/fake/code/egg-scripts/node_modules/egg/node_modules, /Users/fake/code/egg-scripts/test/fixtures/example/node_modules"
    at AgentWorkerLoader.getPluginPath (/Users/fake/code/egg-scripts/node_modules/egg-core/lib/loader/mixin/plugin.js:354:11)
    at AgentWorkerLoader.loadPlugin (/Users/fake/code/egg-scripts/node_modules/egg-core/lib/loader/mixin/plugin.js:108:26)
    at AgentWorkerLoader.loadConfig (/Users/fake/code/egg-scripts/node_modules/egg/lib/loader/agent_worker_loader.js:15:10)
    at new EggApplication (/Users/fake/code/egg-scripts/node_modules/egg/lib/egg.js:50:17)
    at new Agent (/Users/fake/code/egg-scripts/node_modules/egg/lib/agent.js:22:5)
    at Object.<anonymous> (/Users/fake/code/egg-scripts/node_modules/egg-cluster/lib/agent_worker.js:22:15)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
2018-07-09 02:03:30,442 ERROR 2953 nodejs.AgentWorkerDiedError: [master] agent_worker#1:2954 died (code: 1, signal: null)
    at Master.onAgentExit (/Users/fake/code/egg-scripts/node_modules/egg-cluster/lib/master.js:321:17)
    at emitOne (events.js:116:13)
    at Master.emit (events.js:211:7)
    at Messenger.sendToMaster (/Users/fake/code/egg-scripts/node_modules/egg-cluster/lib/utils/messenger.js:122:17)
    at Messenger.send (/Users/fake/code/egg-scripts/node_modules/egg-cluster/lib/utils/messenger.js:87:12)
    at ChildProcess.agentWorker.once (/Users/fake/code/egg-scripts/node_modules/egg-cluster/lib/master.js:220:22)
    at Object.onceWrapper (events.js:317:30)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:198:12)
name: 'AgentWorkerDiedError'
pid: 2953
hostname: MacBookPro.local
```

the plugin loader try to load `egg-onerror` plugin, in three path:

- /Users/fake/code/egg-scripts/test/fixtures/example/node_modules
- /Users/fake/code/egg-scripts/node_modules/egg/node_modules
- /Users/fake/code/egg-scripts/test/fixtures/example/node_modules

but `egg-onerror` was installed into `/Users/fake/code/egg-scripts/node_modules` actually

##### Note:
- use `npminstall` (`cnpm`) works fine, would pass every test cases in `egg-scripts`.
- after apply my commit, works fine, would pass every test cases in `egg-scripts`.
