### PR TITLE
refactor: toAsyncFunction && toPromise

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -351,9 +351,20 @@ class EggCore extends KoaApplication {
   }
 
   /**
-   * use co to wrap generator function to a function return promise
-   * @param  {GeneratorFunction} fn input function
-   * @return {AsyncFunction} async function return promise
+   * Convert a generator function to a promisable one.
+   *
+   * Notice: for other kinds of functions, it directly returns you what it is.
+   *
+   * @param  {Function} fn The inputted function.
+   * @return {AsyncFunction} An async promise-based function.
+   * @example
+   * ```javascript
+   *  const fn = function* (arg) {
+        return arg;
+      };
+      const wrapped = app.toAsyncFunction(fn);
+      wrapped(true).then((value) => console.log(value));
+   * ```
    */
   toAsyncFunction(fn) {
     if (!is.generatorFunction(fn)) return fn;
@@ -364,9 +375,18 @@ class EggCore extends KoaApplication {
   }
 
   /**
-   * use co to wrap array or object to a promise
-   * @param  {Mixed} obj input object
-   * @return {Promise} promise
+   * Convert an object with generator functions to a Promisable one.
+   * @param  {Mixed} obj The inputted object.
+   * @return {Promise} A Promisable result.
+   * @example
+   * ```javascript
+   *  const fn = function* (arg) {
+        return arg;
+      };
+      const arr = [ fn(1), fn(2) ];
+      const promise = app.toPromise(arr);
+      promise.then(res => console.log(res));
+   * ```
    */
   toPromise(obj) {
     return co(function* () {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "autod": "autod",
-    "lint": "eslint lib test *.js",
-    "test": "npm run lint && egg-bin test",
+    "lint": "eslint .",
+    "test": "npm run lint -- --fix && egg-bin test",
     "test-local": "egg-bin test",
     "cov": "egg-bin cov",
     "pkgfiles": "egg-bin pkgfiles",

--- a/test/egg.test.js
+++ b/test/egg.test.js
@@ -415,6 +415,12 @@ describe('test/egg.test.js', () => {
       const wrapped = app.toAsyncFunction(fn);
       return wrapped(true).then(res => assert(res === true));
     });
+
+    it('not translate common values', () => {
+      const primitiveValues = [ 1, 2, 3, 4, 5, 6 ];
+      const wrapped = app.toAsyncFunction(primitiveValues);
+      return assert(wrapped === primitiveValues);
+    });
   });
 
   describe('toPromise', () => {


### PR DESCRIPTION
1) Change comments for `toPromise` (no need to say with the help of `co`
here but in the document is enough).

2) Add a unit test when the param isn't a function type for
`toAsyncFunction`.

3) Use `--fix` to auto fix the formation when doing eslint's type
checking.

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
