### PR TITLE
refactor(ContextLoader): remove ClassLoader

### DIFF
--- a/lib/loader/context_loader.js
+++ b/lib/loader/context_loader.js
@@ -3,35 +3,7 @@
 const assert = require('assert');
 const is = require('is-type-of');
 const FileLoader = require('./file_loader');
-const CLASSLOADER = Symbol('classLoader');
 const EXPORTS = FileLoader.EXPORTS;
-
-class ClassLoader {
-
-  constructor(options) {
-    assert(options.ctx, 'options.ctx is required');
-    const properties = options.properties;
-    this._cache = new Map();
-    this._ctx = options.ctx;
-
-    for (const property in properties) {
-      this.defineProperty(property, properties[property]);
-    }
-  }
-
-  defineProperty(property, values) {
-    Object.defineProperty(this, property, {
-      get() {
-        let instance = this._cache.get(property);
-        if (!instance) {
-          instance = getInstance(values, this._ctx);
-          this._cache.set(property, instance);
-        }
-        return instance;
-      },
-    });
-  }
-}
 
 /**
  * Same as {@link FileLoader}, but it will attach file to `inject[fieldClass]`. The exports will be lazy loaded, such as `ctx.group.repository`.
@@ -39,7 +11,6 @@ class ClassLoader {
  * @since 1.0.0
  */
 class ContextLoader extends FileLoader {
-
   /**
    * @constructor
    * @param {Object} options - options same as {@link FileLoader}
@@ -48,58 +19,59 @@ class ContextLoader extends FileLoader {
   constructor(options) {
     assert(options.property, 'options.property is required');
     assert(options.inject, 'options.inject is required');
-    const target = options.target = {};
-    if (options.fieldClass) {
-      options.inject[options.fieldClass] = target;
-    }
+
+    // provide an empty target for FileLoader
+    const target = (options.target = Object.create(null));
     super(options);
 
-    const app = this.options.inject;
-    const property = options.property;
+    const app = options.inject;
+    if (options.fieldClass) {
+      app[options.fieldClass] = target;
+    }
 
-    // define ctx.service
-    Object.defineProperty(app.context, property, {
-      get() {
-        // distinguish property cache,
-        // cache's lifecycle is the same with this context instance
-        // e.x. ctx.service1 and ctx.service2 have different cache
-        if (!this[CLASSLOADER]) {
-          this[CLASSLOADER] = new Map();
-        }
-        const classLoader = this[CLASSLOADER];
-
-        let instance = classLoader.get(property);
-        if (!instance) {
-          instance = getInstance(target, this);
-          classLoader.set(property, instance);
-        }
-        return instance;
-      },
-    });
+    definePropertyGetter(app.context, options.property, target);
   }
 }
 
 module.exports = ContextLoader;
 
+const CACHE = Symbol('ctx#instance');
+
+function definePropertyGetter(obj, property, values, ctx) {
+  return Object.defineProperty(obj, property, {
+    get() {
+      const cache = this[CACHE] || (this[CACHE] = new Map());
+
+      let instance = cache.get(property);
+      if (instance == null) {
+        instance = getInstance(values, ctx || this);
+        cache.set(property, instance);
+      }
+
+      return instance;
+    },
+  });
+}
 
 function getInstance(values, ctx) {
-  // it's a directory when it has no exports
-  // then use ClassLoader
-  const Class = values[EXPORTS] ? values : null;
-  let instance;
-  if (Class) {
-    if (is.class(Class)) {
-      instance = new Class(ctx);
-    } else {
-      // it's just an object
-      instance = Class;
+  if (values[EXPORTS]) {
+    if (is.class(values)) {
+      return new values(ctx);
     }
-  // Can't set property to primitive, so check again
-  // e.x. module.exports = 1;
-  } else if (is.primitive(values)) {
-    instance = values;
-  } else {
-    instance = new ClassLoader({ ctx, properties: values });
+    // it's just an object
+    return values;
   }
-  return instance;
+
+  // Can't set property to primitive
+  // e.x. module.exports = 1;
+  if (is.primitive(values)) {
+    return values;
+  }
+
+  // it's a directory when it has no exports
+  const namespace = Object.create(null);
+  for (const property in values) {
+    definePropertyGetter(namespace, property, values[property], ctx);
+  }
+  return namespace;
 }


### PR DESCRIPTION
ClassLoader does nothing but create itself. So why bother adding a new concept?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

ContextLoader

##### Description of change

- remove ClassLoader. Instead create a plain object named `namespace` in `getIntance()`

- use `definePropertyGetter()` to define getters for all service instances (e.g. `b` of `service.a.b`), serivce namespaces (e.g. `a` of `service.a.b`) and `ctx.service` itself
