### PR TITLE
refactor(jest-support): Replace require.extensions with Module._extensions

### DIFF
--- a/lib/loader/file_loader.js
+++ b/lib/loader/file_loader.js
@@ -122,7 +122,7 @@ class FileLoader {
   parse() {
     let files = this.options.match;
     if (!files) {
-      files = (process.env.EGG_TYPESCRIPT === 'true' && utils.extensions.includes('.ts'))
+      files = (process.env.EGG_TYPESCRIPT === 'true' && utils.extensions['.ts'])
         ? [ '**/*.(js|ts)', '!**/*.d.ts' ]
         : [ '**/*.js' ];
     } else {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -5,24 +5,21 @@ const is = require('is-type-of');
 const path = require('path');
 const fs = require('fs');
 const co = require('co');
-const extensions = Object.keys(require.extensions);
-/* istanbul ignore if */
-if (!extensions.length) {
-  // adapt for jest
-  extensions.push('.js', '.node', '.json');
-  if (process.env.EGG_TYPESCRIPT === 'true') {
-    extensions.push('.ts');
-  }
-}
+const BuiltinModule = require('module');
+
+// Guard against poorly mocked module constructors.
+const Module = module.constructor.length > 1
+  ? module.constructor
+  : BuiltinModule;
 
 module.exports = {
-  extensions,
+  extensions: Module._extensions,
 
   loadFile(filepath) {
     try {
       // if not js module, just return content buffer
       const extname = path.extname(filepath);
-      if (extname && !extensions.includes(extname)) {
+      if (extname && !Module._extensions[extname]) {
         return fs.readFileSync(filepath);
       }
       // require js module

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -10,6 +10,7 @@ const BuiltinModule = require('module');
 // Guard against poorly mocked module constructors.
 const Module = module.constructor.length > 1
   ? module.constructor
+  /* istanbul ignore next */
   : BuiltinModule;
 
 module.exports = {

--- a/test/egg-ts.test.js
+++ b/test/egg-ts.test.js
@@ -11,13 +11,13 @@ describe('test/egg-ts.test.js', () => {
 
   beforeEach(() => {
     require.extensions['.ts'] = require.extensions['.js'];
-    loaderUtil.extensions.push('.ts');
+    loaderUtil.extensions['.ts'] = require.extensions['.js'];
   });
 
   afterEach(() => {
     mm.restore();
-    loaderUtil.extensions.splice(loaderUtil.extensions.indexOf('.ts'), 1);
     delete require.extensions['.ts'];
+    delete loaderUtil.extensions['.ts'];
   });
 
   describe('load ts file', () => {


### PR DESCRIPTION
Replace require.extensions with Module._extensions

重构 #188 里的部分实现

**原由**

[beidou](https://github.com/alibaba/beidou) Beidou 2.0版本正在实现 TS的完整支持，[issue](https://github.com/alibaba/beidou/issues/122)。整体方案基于 Babel，不同于egg的 ts-node 模式。

这个模式下，需要对在运行时中 load `.ts` 文件， #188 这个变更，预先读取了 require.extensions，之后在运行时中的 `babel-register` 往 require.extensions 里加钩子，无法让 .ts 加载生效。


看了下变更 PR #188 里的实现，其实是对 Jest 测试的兼容，这里使用 Module._extensions 可以完全达到一样的效果。

Module 读取参考自 [pirates](https://github.com/ariporad/pirates/blob/master/src/index.js#L7)，这也是 babel 依赖的 require hook 包。

##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change
- 使用 Module._extensions 替代 require.extensions
