### PR TITLE
fix: Push plugin path repeatedly

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -346,7 +346,9 @@ module.exports = {
     }
 
     // should find the $cwd/node_modules when test the plugins under npm3
-    lookupDirs.push(path.join(process.cwd(), 'node_modules'));
+    if (process.cwd() !== this.options.baseDir) {
+      lookupDirs.push(path.join(process.cwd(), 'node_modules'));
+    }
 
     for (let dir of lookupDirs) {
       dir = path.join(dir, name);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

##### Description of change
<!-- Provide a description of the change below this comment. -->
mostly `process.cwd()` is equal to `this.options.baseDir`, then the lookupDirs will contain two same plugin path. Determine if they are equal may be better!