### PR TITLE
add symbol type to loadToApp function property argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -432,11 +432,11 @@ export class EggLoader<T = EggCore, Config = any> {
   /**
    * Load files using {@link FileLoader}, inject to {@link Application}
    * @param {String|Array} directory - see {@link FileLoader}
-   * @param {String} property - see {@link FileLoader}
+   * @param {String|symbol} property - see {@link FileLoader}
    * @param {Object} opt - see {@link FileLoader}
    * @since 1.0.0
    */
-  loadToApp(directory: string | string[], property: string, opt?: Partial<FileLoaderOption>): void;
+  loadToApp(directory: string | string[], property: string|symbol, opt?: Partial<FileLoaderOption>): void;
 
   /**
    * Load files using {@link ContextLoader}

--- a/lib/loader/egg_loader.js
+++ b/lib/loader/egg_loader.js
@@ -371,7 +371,7 @@ class EggLoader {
   /**
    * Load files using {@link FileLoader}, inject to {@link Application}
    * @param {String|Array} directory - see {@link FileLoader}
-   * @param {String} property - see {@link FileLoader}
+   * @param {String|symbol} property - see {@link FileLoader}
    * @param {Object} opt - see {@link FileLoader}
    * @since 1.0.0
    */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
loader

##### Description of change
<!-- Provide a description of the change below this comment. -->
Add `symbol` type to the property argument of `loadToApp` function.
The js implementation supports this type of argument, but the typescript declaration does not support this, currently we can not pass `symbol` variable to be the property argument of `loadToApp`. As we use typescript heavily, we want to enable this type of argument.