### PR TITLE
deps: upgrade globby to the latest version for install warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "egg-path-matching": "^1.0.1",
     "extend2": "^1.0.0",
     "get-ready": "^2.0.1",
-    "globby": "^8.0.2",
+    "globby": "^10.0.2",
     "is-type-of": "^1.2.1",
     "koa": "^2.7.0",
     "koa-convert": "^1.2.0",


### PR DESCRIPTION
 install dependencies warning: https://github.com/eggjs/egg/issues/4695

```
warning egg > egg-core > globby > fast-glob > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning egg > egg-core > globby > fast-glob > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
```
need upgrade  globby@8 -> globby@10 (https://github.com/sindresorhus/globby/blob/v10.0.2/package.json)

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
