### PR TITLE
fix: the plugins cannot be found while using pnpm

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -343,6 +343,8 @@ module.exports = {
     for (let i = this.eggPaths.length - 1; i >= 0; i--) {
       const eggPath = this.eggPaths[i];
       lookupDirs.push(path.join(eggPath, 'node_modules'));
+      // should look for {EGG_PATH}/../node_modules when using pnpm
+      lookupDirs.push(path.resolve(eggPath, '..'));
     }
 
     // should find the $cwd/node_modules when test the plugins under npm3


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
Pnpm uses a new non-flat structure to organize the dependencies. While using pnpm, the plugins are located at: `/node_modules/.pnpm/egg@2.30.0/node_modules`.
The modification can allow egg to find the plugins again.