### PR TITLE
fix: plugin loader

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -343,17 +343,20 @@ module.exports = {
     for (let i = this.eggPaths.length - 1; i >= 0; i--) {
       const eggPath = this.eggPaths[i];
       lookupDirs.add(path.join(eggPath, 'node_modules'));
+    }
 
-      // should find the siblings directory of framework when using pnpm
+    // should find the $cwd/node_modules when test the plugins under npm3
+    lookupDirs.add(path.join(process.cwd(), 'node_modules'));
+
+    // should find the siblings directory of framework when using pnpm
+    for (let i = this.eggPaths.length - 1; i >= 0; i--) {
+      const eggPath = this.eggPaths[i];
       // 'node_modules/.pnpm/yadan@2.0.0/node_modules/yadan/node_modules',
       // 'node_modules/.pnpm/yadan@2.0.0/node_modules',  <- this is the sibling directory
       // 'node_modules/.pnpm/egg@2.33.1/node_modules/egg/node_modules',
       // 'node_modules/.pnpm/egg@2.33.1/node_modules', <- this is the sibling directory
       lookupDirs.add(path.dirname(eggPath));
     }
-
-    // should find the $cwd/node_modules when test the plugins under npm3
-    lookupDirs.add(path.join(process.cwd(), 'node_modules'));
 
     for (let dir of lookupDirs) {
       dir = path.join(dir, name);

--- a/test/fixtures/plugin-duplicate/node_modules/@scope/a/config/config.default.js
+++ b/test/fixtures/plugin-duplicate/node_modules/@scope/a/config/config.default.js
@@ -1,0 +1,1 @@
+exports.pluginA = 1;

--- a/test/fixtures/plugin-duplicate/node_modules/@scope/a/package.json
+++ b/test/fixtures/plugin-duplicate/node_modules/@scope/a/package.json
@@ -1,0 +1,8 @@
+{
+  "eggPlugin": {
+    "name": "a-duplicate",
+    "optionalDependencies": [
+      "a"
+    ]
+  }
+}

--- a/test/fixtures/plugin-duplicate/node_modules/@scope/b/config/config.default.js
+++ b/test/fixtures/plugin-duplicate/node_modules/@scope/b/config/config.default.js
@@ -1,0 +1,1 @@
+exports.pluginB = 2;

--- a/test/fixtures/plugin-duplicate/node_modules/@scope/b/package.json
+++ b/test/fixtures/plugin-duplicate/node_modules/@scope/b/package.json
@@ -1,0 +1,5 @@
+{
+  "eggPlugin": {
+    "name": "b"
+  }
+}

--- a/test/fixtures/plugin-duplicate/node_modules/a/config/config.default.js
+++ b/test/fixtures/plugin-duplicate/node_modules/a/config/config.default.js
@@ -1,0 +1,1 @@
+exports.pluginA = 1;

--- a/test/fixtures/plugin-duplicate/node_modules/a/package.json
+++ b/test/fixtures/plugin-duplicate/node_modules/a/package.json
@@ -1,0 +1,5 @@
+{
+  "eggPlugin": {
+    "name": "a"
+  }
+}

--- a/test/fixtures/plugin-duplicate/release/config/plugin.js
+++ b/test/fixtures/plugin-duplicate/release/config/plugin.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  b: {
+    enable: true,
+    package: '@scope/b',
+  },
+  "a-duplicate": {
+    enable: true,
+    package: '@scope/a',
+  },
+  a: {
+    enable: true,
+    package: 'a',
+  },
+};

--- a/test/fixtures/plugin-duplicate/release/package.json
+++ b/test/fixtures/plugin-duplicate/release/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "plugin-duplicate"
+}

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -605,4 +605,43 @@ describe('test/load_plugin.test.js', function() {
     assert(loader.allPlugins.gw.enable === false);
     assert(loader.allPlugins.rpcServer.enable === false);
   });
+
+  it('should load plugin with duplicate plugin dir from eggPaths', () => {
+    class BaseApplication extends EggCore {
+      get [Symbol.for('egg#loader')]() {
+        return EggLoader;
+      }
+      get [Symbol.for('egg#eggPath')]() {
+        return utils.getFilepath(path.join('plugin-duplicate'));
+      }
+    }
+
+    class Application extends BaseApplication {
+      get [Symbol.for('egg#loader')]() {
+        return EggLoader;
+      }
+      get [Symbol.for('egg#eggPath')]() {
+        return utils.getFilepath(path.join('plugin-duplicate', 'node_modules', '@scope', 'b'));
+      }
+    }
+
+    const baseDir = utils.getFilepath('plugin-duplicate');
+    app = utils.createApp(path.join('plugin-duplicate', 'release'), {
+      Application,
+    });
+    const loader = app.loader;
+    loader.loadPlugin();
+    loader.loadConfig();
+
+    assert.deepEqual(loader.plugins['a-duplicate'], {
+      enable: true,
+      name: 'a-duplicate',
+      dependencies: [],
+      optionalDependencies: [ 'a' ],
+      env: [],
+      package: '@scope/a',
+      path: path.join(baseDir, 'node_modules', '@scope', 'a'),
+      from: path.join(baseDir, 'release', 'config', 'plugin.js'),
+    });
+  });
 });


### PR DESCRIPTION
pnpm 的匹配规则需要作为兜底匹配，顺序放到支持 pnpm 前的 `lookupDirs` 路径列表之后，这样能保持 `egg-core` 的 plugin loader 不会有 break。