### PR TITLE
feat: add load plugin methods

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -59,45 +59,14 @@ module.exports = {
   loadPlugin() {
     this.timing.start('Load Plugin');
 
-    // loader plugins from application
-    const appPlugins = this.readPluginConfigs(path.join(this.options.baseDir, 'config/plugin.default'));
-    debug('Loaded app plugins: %j', Object.keys(appPlugins));
-
-    // loader plugins from framework
-    const eggPluginConfigPaths = this.eggPaths.map(eggPath => path.join(eggPath, 'config/plugin.default'));
-    const eggPlugins = this.readPluginConfigs(eggPluginConfigPaths);
-    debug('Loaded egg plugins: %j', Object.keys(eggPlugins));
-
-    // loader plugins from process.env.EGG_PLUGINS
-    let customPlugins;
-    if (process.env.EGG_PLUGINS) {
-      try {
-        customPlugins = JSON.parse(process.env.EGG_PLUGINS);
-      } catch (e) {
-        debug('parse EGG_PLUGINS failed, %s', e);
-      }
-    }
-
-    // loader plugins from options.plugins
-    if (this.options.plugins) {
-      customPlugins = Object.assign({}, customPlugins, this.options.plugins);
-    }
-
-    if (customPlugins) {
-      for (const name in customPlugins) {
-        this.normalizePluginConfig(customPlugins, name);
-      }
-      debug('Loaded custom plugins: %j', Object.keys(customPlugins));
-    }
-
     this.allPlugins = {};
-    this.appPlugins = appPlugins;
-    this.customPlugins = customPlugins;
-    this.eggPlugins = eggPlugins;
+    this.appPlugins = this.loadAppPlugins();
+    this.eggPlugins = this.loadEggPlugins();
+    this.customPlugins = this.loadCustomPlugins();
 
-    this._extendPlugins(this.allPlugins, eggPlugins);
-    this._extendPlugins(this.allPlugins, appPlugins);
-    this._extendPlugins(this.allPlugins, customPlugins);
+    this._extendPlugins(this.allPlugins, this.eggPlugins);
+    this._extendPlugins(this.allPlugins, this.appPlugins);
+    this._extendPlugins(this.allPlugins, this.customPlugins);
 
     const enabledPluginNames = []; // enabled plugins that configured explicitly
     const plugins = {};
@@ -125,7 +94,7 @@ module.exports = {
     }
 
     // retrieve the ordered plugins
-    this.orderPlugins = this.getOrderPlugins(plugins, enabledPluginNames, appPlugins);
+    this.orderPlugins = this.getOrderPlugins(plugins, enabledPluginNames, this.appPlugins);
 
     const enablePlugins = {};
     for (const plugin of this.orderPlugins) {
@@ -141,6 +110,47 @@ module.exports = {
     this.plugins = enablePlugins;
 
     this.timing.end('Load Plugin');
+  },
+
+  loadAppPlugins() {
+    // loader plugins from application
+    const appPlugins = this.readPluginConfigs(path.join(this.options.baseDir, 'config/plugin.default'));
+    debug('Loaded app plugins: %j', Object.keys(appPlugins));
+    return appPlugins;
+  },
+
+  loadEggPlugins() {
+    // loader plugins from framework
+    const eggPluginConfigPaths = this.eggPaths.map(eggPath => path.join(eggPath, 'config/plugin.default'));
+    const eggPlugins = this.readPluginConfigs(eggPluginConfigPaths);
+    debug('Loaded egg plugins: %j', Object.keys(eggPlugins));
+    return eggPlugins;
+  },
+
+  loadCustomPlugins() {
+    // loader plugins from process.env.EGG_PLUGINS
+    let customPlugins;
+    if (process.env.EGG_PLUGINS) {
+      try {
+        customPlugins = JSON.parse(process.env.EGG_PLUGINS);
+      } catch (e) {
+        debug('parse EGG_PLUGINS failed, %s', e);
+      }
+    }
+
+    // loader plugins from options.plugins
+    if (this.options.plugins) {
+      customPlugins = Object.assign({}, customPlugins, this.options.plugins);
+    }
+
+    if (customPlugins) {
+      for (const name in customPlugins) {
+        this.normalizePluginConfig(customPlugins, name);
+      }
+      debug('Loaded custom plugins: %j', Object.keys(customPlugins));
+    }
+
+    return customPlugins;
   },
 
   /*

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -67,6 +67,29 @@ describe('test/load_plugin.test.js', function() {
     assert(loader.orderPlugins instanceof Array);
   });
 
+  it('should loadPlugin with order', function() {
+    app = utils.createApp('plugin');
+    const loader = app.loader;
+    const loaderOrders = [];
+    [
+      'loadAppPlugins',
+      'loadEggPlugins',
+      'loadCustomPlugins',
+    ].forEach(method => {
+      mm(loader, method, () => {
+        loaderOrders.push(method);
+        return {};
+      });
+    });
+
+    loader.loadPlugin();
+    assert.deepEqual(loaderOrders, [
+      'loadAppPlugins',
+      'loadEggPlugins',
+      'loadCustomPlugins',
+    ]);
+  });
+
   it('should follow the search order，node_modules of application > node_modules of framework', function() {
     const baseDir = utils.getFilepath('plugin');
     app = utils.createApp('plugin');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

将几个 plugin 加载逻辑独立出来单独函数，允许上层封装框架在 loader 层面变更插件开关情况。

> 在 Chair 中目前存在根据应用的环境情况，动态开关相关插件的场景，目前只能在 loadPlugin 之后做，导致要手动去篡改 this.plugins 和 this.orderPlugins ，有点不太合理

##### Description of change
<!-- Provide a description of the change below this comment. -->
