### PR TITLE
feat: extract plugin loader method for override

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -61,8 +61,8 @@ module.exports = {
 
     this.lookupDirs = this.getLookupDirs();
     this.allPlugins = {};
-    this.appPlugins = this.loadAppPlugins();
     this.eggPlugins = this.loadEggPlugins();
+    this.appPlugins = this.loadAppPlugins();
     this.customPlugins = this.loadCustomPlugins();
 
     this._extendPlugins(this.allPlugins, this.eggPlugins);

--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -59,6 +59,7 @@ module.exports = {
   loadPlugin() {
     this.timing.start('Load Plugin');
 
+    this.lookupDirs = this.getLookupDirs();
     this.allPlugins = {};
     this.appPlugins = this.loadAppPlugins();
     this.eggPlugins = this.loadEggPlugins();
@@ -336,17 +337,7 @@ module.exports = {
     return result.sequence.map(name => allPlugins[name]);
   },
 
-  // Get the real plugin path
-  getPluginPath(plugin) {
-    if (plugin.path) {
-      return plugin.path;
-    }
-
-    if (plugin.package) {
-      assert(isValidatePackageName(plugin.package), `plugin ${plugin.name} invalid, use 'path' instead of package: "${plugin.package}"`);
-    }
-
-    const name = plugin.package || plugin.name;
+  getLookupDirs() {
     const lookupDirs = new Set();
 
     // try to locate the plugin in the following directories's node_modules
@@ -362,6 +353,25 @@ module.exports = {
     // should find the $cwd when test the plugins under npm3
     lookupDirs.add(process.cwd());
 
+    return lookupDirs;
+  },
+
+  // Get the real plugin path
+  getPluginPath(plugin) {
+    if (plugin.path) {
+      return plugin.path;
+    }
+
+    if (plugin.package) {
+      assert(isValidatePackageName(plugin.package), `plugin ${plugin.name} invalid, use 'path' instead of package: "${plugin.package}"`);
+    }
+
+    return this._resolvePluginPath(plugin);
+  },
+
+  _resolvePluginPath(plugin) {
+    const name = plugin.package || plugin.name;
+
     try {
       // should find the plugin directory
       // pnpm will lift the node_modules to the sibling directory
@@ -369,10 +379,10 @@ module.exports = {
       // 'node_modules/.pnpm/yadan@2.0.0/node_modules',  <- this is the sibling directory
       // 'node_modules/.pnpm/egg@2.33.1/node_modules/egg/node_modules',
       // 'node_modules/.pnpm/egg@2.33.1/node_modules', <- this is the sibling directory
-      const filePath = require.resolve(`${name}/package.json`, { paths: [ ...lookupDirs ] });
+      const filePath = require.resolve(`${name}/package.json`, { paths: [ ...this.lookupDirs ] });
       return path.dirname(filePath);
     } catch (_) {
-      throw new Error(`Can not find plugin ${name} in "${[ ...lookupDirs ].join(', ')}"`);
+      throw new Error(`Can not find plugin ${name} in "${[ ...this.lookupDirs ].join(', ')}"`);
     }
   },
 

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -72,8 +72,8 @@ describe('test/load_plugin.test.js', function() {
     const loader = app.loader;
     const loaderOrders = [];
     [
-      'loadAppPlugins',
       'loadEggPlugins',
+      'loadAppPlugins',
       'loadCustomPlugins',
     ].forEach(method => {
       mm(loader, method, () => {
@@ -84,8 +84,8 @@ describe('test/load_plugin.test.js', function() {
 
     loader.loadPlugin();
     assert.deepEqual(loaderOrders, [
-      'loadAppPlugins',
       'loadEggPlugins',
+      'loadAppPlugins',
       'loadCustomPlugins',
     ]);
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

对 `getPluginPath()` 的方法进行拆分，以便在 layer 层可以覆盖掉 resolve 的逻辑。

解决 https://github.com/eggjs/egg-core/pull/238 对我们 layer 模式带来的影响。

在 Layer 层用这段逻辑覆盖回去：https://github.com/eggjs/egg-core/blob/4.22.0/lib/loader/mixin/plugin.js#L358