### PR TITLE
feat: dump plugin info when it implicit enable by dependents plugin

### DIFF
--- a/lib/loader/mixin/plugin.js
+++ b/lib/loader/mixin/plugin.js
@@ -311,8 +311,14 @@ module.exports = {
       if (!allPlugins[name].enable) {
         implicitEnabledPlugins.push(name);
         allPlugins[name].enable = true;
+        allPlugins[name].implicitEnable = true;
       }
     });
+
+    for (const [ name, dependents ] of Object.entries(requireMap)) {
+      // note:`dependents` will not includes `optionalDependencies`
+      allPlugins[name].dependents = dependents;
+    }
 
     // Following plugins will be enabled implicitly.
     //   - configclient required by [hsfclient]

--- a/test/loader/mixin/load_plugin.test.js
+++ b/test/loader/mixin/load_plugin.test.js
@@ -641,6 +641,10 @@ describe('test/load_plugin.test.js', function() {
       'tracelog',
       'gateway',
     ]);
+
+    assert(loader.allPlugins.zoneclient.enable === true);
+    assert(loader.allPlugins.zoneclient.implicitEnable === true);
+    assert.deepEqual(loader.allPlugins.zoneclient.dependents, [ 'ldc' ]);
   });
 
   it('should load plugin from scope', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/227713/195763759-9fdd3225-7407-42e5-8a27-07267dd9a44e.png">


**note: `dependents` will not includes `optionalDependencies`**
**note: `dependents` will not includes `optionalDependencies`**
**note: `dependents` will not includes `optionalDependencies`**

