### PR TITLE
fix: @types/depd and @types/koa should be dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "node": ">= 14.17.0"
   },
   "devDependencies": {
-    "@types/depd": "^1.1.32",
-    "@types/koa": "^2.0.48",
     "await-event": "^2.1.0",
     "coffee": "^5.2.1",
     "egg-bin": "^5.9.0",
@@ -55,6 +53,8 @@
   },
   "dependencies": {
     "@eggjs/router": "^2.0.0",
+    "@types/depd": "^1.1.32",
+    "@types/koa": "^2.13.5",
     "co": "^4.6.0",
     "debug": "^4.1.1",
     "depd": "^2.0.0",


### PR DESCRIPTION
index.d.ts dependency on them

```ts
import KoaApplication = require('koa');
import depd = require('depd');
```

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
