### PR TITLE
fix: handle digits after separator in defaultCamelize

### DIFF
--- a/lib/loader/file_loader.js
+++ b/lib/loader/file_loader.js
@@ -240,7 +240,8 @@ function defaultCamelize(filepath, caseStyle) {
     // FooBar.js  > FooBar
     // FooBar.js  > FooBar
     // FooBar.js  > fooBar (if lowercaseFirst is true)
-    property = property.replace(/[_-][a-z]/ig, s => s.substring(1).toUpperCase());
+    // aaa_00.js  > aaa00 (digits after separator should also be handled)
+    property = property.replace(/[_-][a-z0-9]/ig, s => s.substring(1).toUpperCase());
     let first = property[0];
     switch (caseStyle) {
       case 'lower':

--- a/test/fixtures/load_dirs/camelize/foo_00.js
+++ b/test/fixtures/load_dirs/camelize/foo_00.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/loader/file_loader.test.js
+++ b/test/loader/file_loader.test.js
@@ -265,6 +265,7 @@ describe('test/loader/file_loader.test.js', () => {
       assert(target.FooBar2);
       assert(target.FooBar3);
       assert(target.FooBar4);
+      assert(target.Foo00);
     });
 
     it('should load when caseStyle = camel', () => {
@@ -279,6 +280,7 @@ describe('test/loader/file_loader.test.js', () => {
       assert(target.fooBar2);
       assert(target.FooBar3);
       assert(target.fooBar4);
+      assert(target.foo00);
     });
 
     it('should load when caseStyle = lower', () => {
@@ -293,6 +295,7 @@ describe('test/loader/file_loader.test.js', () => {
       assert(target.fooBar2);
       assert(target.fooBar3);
       assert(target.fooBar4);
+      assert(target.foo00);
     });
 
     it('should load when caseStyle is function', () => {
@@ -312,6 +315,7 @@ describe('test/loader/file_loader.test.js', () => {
       assert(target.fooBar2);
       assert(target.FooBar3);
       assert(target['foo-bar4']);
+      assert(target.foo00);
     });
 
     it('should throw when caseStyle do not return array', () => {
@@ -340,6 +344,21 @@ describe('test/loader/file_loader.test.js', () => {
       assert(target.fooBar2);
       assert(target.fooBar3);
       assert(target.fooBar4);
+      assert(target.foo00);
+    });
+
+    it('should handle separator before digits correctly', () => {
+      const target = {};
+      new FileLoader({
+        directory: path.join(dirBase, 'camelize'),
+        target,
+        caseStyle: 'upper',
+      }).load();
+
+      // foo_00.js should camelize to Foo00, not Foo_00
+      assert(target.Foo00);
+      assert(!target.Foo_00);
+      assert(!target['Foo_00']);
     });
   });
 

--- a/test/loader/file_loader.test.js
+++ b/test/loader/file_loader.test.js
@@ -358,7 +358,6 @@ describe('test/loader/file_loader.test.js', () => {
       // foo_00.js should camelize to Foo00, not Foo_00
       assert(target.Foo00);
       assert(!target.Foo_00);
-      assert(!target['Foo_00']);
     });
   });
 


### PR DESCRIPTION
## Summary

- `defaultCamelize` regex `[_-][a-z]` only handled separators followed by letters, leaving separators before digits untouched (e.g. `foo_00.js` → `foo_00` instead of `foo00`)
- Extended regex to `[_-][a-z0-9]` so underscores/hyphens before digits are also removed during camelization
- Added test fixture `foo_00.js` and assertions covering this edge case across all caseStyle modes

## Test plan

- [x] Existing `file_loader.test.js` caseStyle tests pass with new fixture
- [x] New test case `should handle separator before digits correctly` verifies `Foo00` is set and `Foo_00` is not
- [x] Full test suite passes (the 1 flaky timeout in `load_service.test.js` is a pre-existing parallel race condition)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camelization so identifiers with separators (underscores/dashes) followed by digits are transformed correctly (e.g., separator+digits become contiguous capitalized segments).

* **Tests**
  * Added tests verifying correct handling of separator-before-digit cases across multiple naming styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->